### PR TITLE
Use object instead of array for ad info

### DIFF
--- a/ad-scraper.js
+++ b/ad-scraper.js
@@ -6,7 +6,7 @@ var cheerio = require("cheerio");
 
 /*Parses the HTML of a Kijiji ad for its important information*/
 var parseHTML = function(html) {
-    var ad = {"info": []};
+    var ad = {"info": {}};
     var $ = cheerio.load(html);
 
     //Get ad title and main image


### PR DESCRIPTION
Currently the info property of an ad is instantiated as an Array but used as an Object. This causes bugs in other libraries which use the ad object.
