### PR TITLE
Allow suppression of query result scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Will call `callback` with an array of detailed ad objects.
 
 Values for `locationId` and `categoryId` can be found by performing a search and looking at the POST request parameters or the URL Kijiji redirects to. For example, after setting the location to Ottawa and selecting the "cars & vehicles" category, Kijiji redirects to http://www.kijiji.ca/b-cars-vehicles/ottawa/c27l1700185. The last part of the URL (c27l1700185) is formatted as c[categoryId]l[locationId]. So in this case, `categoryId` is 27 and `locationId` is 1700185.
 
+By default, each query result is scraped. To suppress this behavior and return only the data retrieved by the initial query, set the `scrape` preference to `false`.
+
 * `params` - Contains Kijiji ad search criteria:
 ```js
 {
@@ -64,7 +66,7 @@ Values for `locationId` and `categoryId` can be found by performing a search and
 
 There are many different search parameters, most of which vary by category type. They can be found by using your browser's developer tools and performing a custom search on Kijiji.
 
-* `callback(err, ads)` - A callback called after Kijiji has been searched. If there is an error, `err` will not be null. If everything was successful, `ads` will contain detailed ad objects. These are different from the ad objects returned by `scrape()`, since this function uses Kijiji's RSS functionality. They contain a key/value mapping for every field iniside an ad's `<item>` tag in the RSS feed, as well as an `innerAd` object, which is identical to the ad object returned by `scrape()`. These more detailed ads are of the form
+* `callback(err, ads)` - A callback called after Kijiji has been searched. If there is an error, `err` will not be null. If everything was successful, `ads` will contain detailed ad objects. These are different from the ad objects returned by `scrape()`, since this function uses Kijiji's RSS functionality. They contain a key/value mapping for every field inside an ad's `<item>` tag in the RSS feed. If the `scrape` preference was not given as `false`, each ad will also contain an `innerAd` object, which is identical to the ad object returned by `scrape()`. These more detailed ads are of the form
 ```js
 {
     "title": "ad title",

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ Will call `callback` with an array of detailed ad objects.
 ```js
 {
     "locationId": <Kijiji location id>,
-    "categoryId": <Kijiji ad category id>
+    "categoryId": <Kijiji ad category id>,
+    "scrapeInnerAd": true/false (default true)
 }
 ```
 
 Values for `locationId` and `categoryId` can be found by performing a search and looking at the POST request parameters or the URL Kijiji redirects to. For example, after setting the location to Ottawa and selecting the "cars & vehicles" category, Kijiji redirects to http://www.kijiji.ca/b-cars-vehicles/ottawa/c27l1700185. The last part of the URL (c27l1700185) is formatted as c[categoryId]l[locationId]. So in this case, `categoryId` is 27 and `locationId` is 1700185.
 
-By default, each query result is scraped. To suppress this behavior and return only the data retrieved by the initial query, set the `scrape` preference to `false`.
+By default, the details of each query result are scraped in separate, subsequent requests. To suppress this behavior and return only the data retrieved by the initial query, set the `scrapeInnerAd` preference to `false`.
 
 * `params` - Contains Kijiji ad search criteria:
 ```js
@@ -66,7 +67,7 @@ By default, each query result is scraped. To suppress this behavior and return o
 
 There are many different search parameters, most of which vary by category type. They can be found by using your browser's developer tools and performing a custom search on Kijiji.
 
-* `callback(err, ads)` - A callback called after Kijiji has been searched. If there is an error, `err` will not be null. If everything was successful, `ads` will contain detailed ad objects. These are different from the ad objects returned by `scrape()`, since this function uses Kijiji's RSS functionality. They contain a key/value mapping for every field inside an ad's `<item>` tag in the RSS feed. If the `scrape` preference was not given as `false`, each ad will also contain an `innerAd` object, which is identical to the ad object returned by `scrape()`. These more detailed ads are of the form
+* `callback(err, ads)` - A callback called after Kijiji has been searched. If there is an error, `err` will not be null. If everything was successful, `ads` will contain detailed ad objects. These are different from the ad objects returned by `scrape()`, since this function uses Kijiji's RSS functionality. They contain a key/value mapping for every field inside an ad's `<item>` tag in the RSS feed plus an `innerAd` property. This property will contain an object identical to the ad object returned by `scrape()` unless `scrapeInnerAd` was given as `false`, in which case the property will contain an empty object. These more detailed ads are of the form
 ```js
 {
     "title": "ad title",

--- a/kijiji-query.js
+++ b/kijiji-query.js
@@ -61,7 +61,7 @@ var query = function(prefs, params, callback) {
         if (err) return callback(err, null);
 
         var ads = parseXML(body);
-        if (prefs.scrape !== false) {
+        if (prefs.scrapeInnerAd !== false) {
             scrapeAdLinks(ads, callback);
         } else {
             callback(null, ads);

--- a/kijiji-query.js
+++ b/kijiji-query.js
@@ -21,7 +21,6 @@ var scrapeAdLinks = function(ads, callback) {
 
     //Scrape each ad
     for (var i=0; i < ads.length; i++) {
-        ads[i].innerAd = {};
         scrapeAdLink(ads[i], function(err) {
             if (err) return callback(err, null);
 
@@ -45,6 +44,7 @@ var parseXML = function(xml) {
             ad[child.name] = $(child).text();
         });
 
+        ad.innerAd = {};
         ads.push(ad);
     });
 

--- a/kijiji-query.js
+++ b/kijiji-query.js
@@ -21,9 +21,10 @@ var scrapeAdLinks = function(ads, callback) {
 
     //Scrape each ad
     for (var i=0; i < ads.length; i++) {
+        ads[i].innerAd = {};
         scrapeAdLink(ads[i], function(err) {
             if (err) return callback(err, null);
-            
+
             //Call callback once everything is scraped
             if (++scraped === ads.length) {
                 return callback(null, ads);
@@ -42,9 +43,8 @@ var parseXML = function(xml) {
         var ad = {};
         $(item).children().each(function(i, child) {
             ad[child.name] = $(child).text();
-        });    
-    
-        ad.innerAd = {};
+        });
+
         ads.push(ad);
     });
 
@@ -59,7 +59,13 @@ var query = function(prefs, params, callback) {
     //Search Kijiji
     request({"url": url, "qs": params}, function(err, res, body) {
         if (err) return callback(err, null);
-        scrapeAdLinks(parseXML(body), callback);
+
+        var ads = parseXML(body);
+        if (prefs.scrape !== false) {
+            scrapeAdLinks(ads, callback);
+        } else {
+            callback(null, ads);
+        }
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A scraper for Kijiji ads",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
It's super convenient that the library calls `scrape()` on every item in a query by default. However, I'd like to query fairly frequently (every few minutes) and I'm worried that this sort of behaviour is readily identifiable as bot-like. This pull request adds support for a query preference, `scrape`, which, when set to `false`, causes `query()` to return only what data can be gleaned from the RSS feed. The consumer of the data can then make a decision about whether or not to call `scrape()` on an ad (based on e.g. whether or not the ad has already been retrieved and stored locally).