### PR TITLE
Expose more and better ad images

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Will call `callback` with an object representing the ad at `url`.
 {
     "title": "ad title",
     "image": "ad image URL",
+    "images": ["ad image URL 1", "ad image URL 2", ..., "ad image URL n"],
     "desc": "ad description"
     "info": [<category-specific keys and values>]
 }
 ```
+
+The image URL given in `image` is the featured image for the ad and will be up to 300x300. The image URLs given in `images` are all of the images associated with the ad and each may be up to 1024x1024.
 
 ##### Example usage
 ```js

--- a/ad-scraper.js
+++ b/ad-scraper.js
@@ -12,6 +12,12 @@ var parseHTML = function(html) {
     //Get ad title and main image
     ad.title = $("span[itemprop=name]").text();
     ad.image = $("img[itemprop=image]").attr("src");
+    ad.images = $("img[itemprop=image]").map(function (_, el) {
+        /* Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
+         * number between 0 and 140 indicating the desired image size and
+         * quality. "57" is up to 1024x1024, the largest I've found. */
+        return $(el).attr("src").replace(/\/\$_\d+\.JPG$/, '/$_57.JPG');
+    }).get();
     
     //Remove link to map and dividers from info table
     $("#MapLink").remove();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A scraper for Kijiji ads",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The listing image gallery is trivially accessible to the parser. This pull request makes the images available to the user via another property on the ad, `images`. Some attempt is made to provide the consumer with higher-resolution images than the Kijiji web interface would have you know exists.

(Two PRs in the same day – if you want me to shut up, that's fine...)