### PR TITLE
Fix scrape numeric data such as Kilometers, Stock # for cars

### DIFF
--- a/ad-scraper.js
+++ b/ad-scraper.js
@@ -49,7 +49,7 @@ function parseHTML(html) {
         });
         adData.VIP.adAttributes.forEach(function(a) {
             var attr = a.localeSpecificValues.en;
-            ad.info[attr.label] = attr.value;
+            ad.info[attr.label] = a.machineValue;
         });
 
         // Other attributes of interest (I'm attempting to match the old output)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A scraper for Kijiji ads",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Sometimes, attr.value is set as NULL when the english / french rendering of the data is the same (ie: KMs, Stock #). 

This PR retrieves data properly in that case. 