### PR TITLE
Add null check to getSearchResults & getPageResults

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -121,18 +121,11 @@ function getPageResults(params, pageNum, firstResultPagePath="") {
         let pagePath = path.replace(LOCATION_REGEX, `$1/page-${pageNum}$2`);
         firstResultPagePath = path;
         
+        // Search Kijiji
         return fetch(KIJIJI_BASE_URL + pagePath).then(res => res.text());
     }).then(function(body) {
         let results = parseResultsHTML(body);
-
-        // Return empty array if results is null instead of exception
-        if (!results) {
-            return {
-                pageResults: [],
-                firstResultPagePath: firstResultPagePath
-            }
-        }
-        return { pageResults: results, firstResultPagePath: firstResultPagePath };
+        return { pageResults: results || [], firstResultPagePath: firstResultPagePath };
     });
 }
 
@@ -153,7 +146,6 @@ function getSearchResults(params, minResults, pageNum=1, results=[], firstResult
         return getSearchResults(params, minResults, pageNum + 1, results, ret.firstResultPagePath);
     });
 }
-
 
 /* Validates that obj.propName exists and is an integer */
 function ensureIntProp(obj, propName) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -120,13 +120,18 @@ function getPageResults(params, pageNum, firstResultPagePath="") {
         // Specify page number. It must be the last path component of the URL
         let pagePath = path.replace(LOCATION_REGEX, `$1/page-${pageNum}$2`);
         firstResultPagePath = path;
-
-        // Search Kijiji
+        
         return fetch(KIJIJI_BASE_URL + pagePath).then(res => res.text());
     }).then(function(body) {
         let results = parseResultsHTML(body);
-        if (!results)
-            throw new Error("Invalid Kijiji HTML on search results page");
+
+        // Return empty array if results is null instead of exception
+        if (!results) {
+            return {
+                pageResults: [],
+                firstResultPagePath: firstResultPagePath
+            }
+        }
         return { pageResults: results, firstResultPagePath: firstResultPagePath };
     });
 }
@@ -134,15 +139,21 @@ function getPageResults(params, pageNum, firstResultPagePath="") {
 /* Retrieves at least minResults search results from Kijiji using the passed parameters */
 function getSearchResults(params, minResults, pageNum=1, results=[], firstResultPagePath="") {
     return getPageResults(params, pageNum, firstResultPagePath).then(function(ret) {
-        results.push(...ret.pageResults);
+        
+        // Check value returned by getPageResults before adding to results array
         if (results.length >= minResults ||
             ret.pageResults.length == 0 ||
             pageNum == MAX_RESULTS_PAGE_NUM) {
             return results;
         }
+        else {
+            results.push(...ret.pageResults);
+        }
+        
         return getSearchResults(params, minResults, pageNum + 1, results, ret.firstResultPagePath);
     });
 }
+
 
 /* Validates that obj.propName exists and is an integer */
 function ensureIntProp(obj, propName) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -132,15 +132,12 @@ function getPageResults(params, pageNum, firstResultPagePath="") {
 /* Retrieves at least minResults search results from Kijiji using the passed parameters */
 function getSearchResults(params, minResults, pageNum=1, results=[], firstResultPagePath="") {
     return getPageResults(params, pageNum, firstResultPagePath).then(function(ret) {
-        
+        results.push(...ret.pageResults);
         // Check value returned by getPageResults before adding to results array
         if (results.length >= minResults ||
             ret.pageResults.length == 0 ||
             pageNum == MAX_RESULTS_PAGE_NUM) {
             return results;
-        }
-        else {
-            results.push(...ret.pageResults);
         }
         
         return getSearchResults(params, minResults, pageNum + 1, results, ret.firstResultPagePath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A scraper for Kijiji ads",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Hey, so I revised your getSearchResults and getPageResults function: rather than throwing an error each time the parseResultsHTML returns null (which can be annoying), I made it return an empty page results array.

Let me know if you are ok with this change! 