### PR TITLE
Services search fix

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -4,7 +4,7 @@
 const fetch = require("node-fetch");
 const cheerio = require("cheerio");
 
-const IMG_REGEX = /\/\$_\d+\.JPG$/;
+const IMG_REGEX = /\/\$_\d+\.(?:JPG|PNG)$/;
 
 function cleanDesc(text) {
     // Some descriptions contain HTML. Remove it so it is only text
@@ -49,11 +49,16 @@ function parseHTML(html) {
         !adData.config.hasOwnProperty("VIP")) {
         return null;
     }
+
     adData = adData.config;
     info.title = adData.adInfo.title;
-    info.image = adData.adInfo.sharingImageUrl
     info.description = cleanDesc(adData.VIP.description);
     info.date = new Date(adData.VIP.sortingDate);
+
+    info.image = adData.adInfo.sharingImageUrl;
+    if (info.image) {
+        info.image = info.image.replace(IMG_REGEX, "/$_57.JPG");
+    }
 
     /* Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
        number between 0 and 140 indicating the desired image size and

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -55,14 +55,14 @@ function parseHTML(html) {
     info.description = cleanDesc(adData.VIP.description);
     info.date = new Date(adData.VIP.sortingDate);
 
+    /* Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
+       number between 0 and 140 indicating the desired image size and
+       quality. "57" is up to 1024x1024, the largest I've found. */
     info.image = adData.adInfo.sharingImageUrl;
     if (info.image) {
         info.image = info.image.replace(IMG_REGEX, "/$_57.JPG");
     }
 
-    /* Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
-       number between 0 and 140 indicating the desired image size and
-       quality. "57" is up to 1024x1024, the largest I've found. */
     adData.VIP.media.forEach(function(m) {
         if (m.type == "image") {
             info.images.push(m.href.replace(IMG_REGEX, "/$_57.JPG"));

--- a/lib/search.js
+++ b/lib/search.js
@@ -12,7 +12,7 @@ const packageJson = require("../package.json");
 
 const KIJIJI_BASE_URL = "https://www.kijiji.ca";
 const KIJIJI_SEARCH_URL = KIJIJI_BASE_URL + "/b-search.html";
-const IMG_REGEX = /\/\$_\d+\.JPG$/;
+const IMG_REGEX = /\/s\-l\d+\.jpg$/;
 const LOCATION_REGEX = /(.+)(\/.*)$/;
 
 /* Converts a date from a Kijiji ad result into a date object
@@ -73,7 +73,7 @@ function parseResultsHTML(html) {
                     // `src` starts off with a placeholder image and will
                     // remain if the ad has no image
                     $(item).find(".image img").data("src") || $(item).find(".image img").attr("src") || ""
-                ).replace(IMG_REGEX, "/$_57.jpg"),
+                ).replace(IMG_REGEX, "/s-l2000.jpg"),
 
                 date: dateFromRelativeDateString(
                     // For some reason, some categories (like anything under

--- a/lib/search.js
+++ b/lib/search.js
@@ -55,7 +55,7 @@ function parseResultsHTML(html) {
     let $ = cheerio.load(html);
 
     // Get info for each ad
-    let allAdElements = $(".search-item");
+    let allAdElements = $(".regular-ad");
     let filteredAdElements = allAdElements.not(".third-party");
     if (filteredAdElements.length === 0) {
         return [];
@@ -65,10 +65,24 @@ function parseResultsHTML(html) {
         try {
             let url = KIJIJI_BASE_URL + $(item).find("a.title").attr("href");
             let info = {
-                "title": $(item).find("a.title").text().trim(),
-                "image": $(item).find(".image img").attr("src").replace(IMG_REGEX, "/$_57.JPG"),
-                "date": dateFromRelativeDateString($(item).find(".date-posted").text().trim()),
-                "description": $(this).find(".description").text().trim(),
+                title: $(item).find("a.title").text().trim(),
+
+                image: (
+                    // `data-src` contains the URL of the image to lazy load
+                    //
+                    // `src` starts off with a placeholder image and will
+                    // remain if the ad has no image
+                    $(item).find(".image img").data("src") || $(item).find(".image img").attr("src") || ""
+                ).replace(IMG_REGEX, "/$_57.jpg"),
+
+                date: dateFromRelativeDateString(
+                    // For some reason, some categories (like anything under
+                    // SERVICES) use different CSS classes than usual
+                    ($(item).find(".date-posted").text() || $(item).find(".posted").text()).trim()
+                ),
+
+                // Pick a format, Kijiji
+                description: ($(item).find(".description > p").text() || $(item).find(".description").text()).trim()
             };
             adResults = adResults || [];
             adResults.push(new KijijiAd(url, info));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "A scraper for Kijiji ads",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Kijiji uses slightly different markup for some search result pages (like anything under the `SERVICES` category). This PR fixes the scraper to work with such result pages.

It also updates the image URL regex used during result page scraping to match Kijiji's new format.