### PR TITLE
Make use of Kijiji mobile API (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,13 @@ Searches are performed using the `search()` function:
 
 * `options` (optional) - Contains parameters that control the behavior of searching and scraping. Can be omitted. In addition to the options below, you can also specify everything in [Scraper Options](#scraper-options).
 
-    |Option               |Type   |Default Value|Description|
-    |---------------------|-------|-------------|-----------|
-    |`scrapeResultDetails`|Boolean|`true`      |By default, the details of each query result are scraped in separate, subsequent requests. To suppress this behavior and return only the data retrieved by the initial query, set this option to `false`. Note that ads will lack some information if you do this and `Ad.isScraped()` will return `false` until `Ad.scrape()` is called to retrieve the missing information.|
-    |`minResults`         |Integer|`20`         |Minimum number of ads to fetch (if available). Note that Kijiji results are returned in pages of up to 20 ads, so if you set this to something like 29, up to 40 results may be retrieved.|
-    |`maxResults`         |Integer|`-1`         |Maximum number of ads to return. This simply removes excess results from the array that is returned (i.e., if `minResults` is 40 and `maxResults` is 7, 40 results will be fetched from Kijiji and the last 33 will be discarded). A negative value indicates no limit.|
+    |Option                |Type   |Default Value|Description|
+    |----------------------|-------|-------------|-----------|
+    |`pageDelayMs`         |Integer|`1000`       |Amount of time in milliseconds to wait between scraping each result page. This is useful to avoid detection and bans from Kijiji.|
+    |`minResults`          |Integer|`20`         |Minimum number of ads to fetch (if available). Note that Kijiji results are returned in pages of up to 20 ads, so if you set this to something like 29, up to 40 results may be retrieved.|
+    |`maxResults`          |Integer|`-1`         |Maximum number of ads to return. This simply removes excess results from the array that is returned (i.e., if `minResults` is 40 and `maxResults` is 7, 40 results will be fetched from Kijiji and the last 33 will be discarded). A negative value indicates no limit.|
+    |`scrapeResultDetails` |Boolean|`true`       |When using the HTML scraper, the details of each query result are scraped in separate, subsequent requests by default. To suppress this behavior and return only the data retrieved by the initial query, set this option to `false`. Note that ads will lack some information if you do this and `Ad.isScraped()` will return `false` until `Ad.scrape()` is called to retrieve the missing information. This option does nothing when using the API scraper (default).|
+    |`resultDetailsDelayMs`|Integer|`500`        |When `scrapeResultDetails` is `true`, the amount of time in milliseconds to wait in between each request for result details. A value of 0 will cause all such requests to be made at the same time. This is useful to avoid detection and bans from Kijiji.|
 
 * `callback(err, results)` (optional) - A callback called after the search results have been scraped. If an error occurs during scraping, `err` will not be null. If everything is successful, `results` will contain an array of `Ad` objects.
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,9 @@
 // index.ts
 /* Exports the kijiji-scraper submodules */
 
-export { default as Ad } from "./lib/ad";
-export { default as search } from "./lib/search";
-export { default as locations } from "./lib/locations";
-export { default as categories } from "./lib/categories";
+export { Ad } from "./lib/ad";
+export { AdInfo } from "./lib/scraper";
+export { search, SearchParameters, SearchOptions } from "./lib/search";
+export { ScraperOptions, ScraperType } from "./lib/helpers";
+export { categories } from "./lib/categories";
+export { locations } from "./lib/locations";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     collectCoverage: true,
     collectCoverageFrom: [
-        "lib/*.ts"
+        "lib/**/*.ts"
     ],
     coveragePathIgnorePatterns: [
         "categories.ts",

--- a/lib/ad.ts
+++ b/lib/ad.ts
@@ -1,7 +1,8 @@
 // ad.ts
 /* Kijiji ad object definition */
 
-import scraper, { AdInfo } from "./scraper";
+import { scrape, AdInfo } from "./scraper";
+import { ScraperOptions } from "./helpers";
 
 /* Nicely formats a date string */
 function DateToString(date: Date): string {
@@ -17,7 +18,7 @@ function DateToString(date: Date): string {
  * This class encapsulates a Kijiji ad and its properties. It also
  * handles retrieving this information from Kijiji
  */
-export default class KijijiAd extends AdInfo {
+export class Ad extends AdInfo {
     /**
      * Manually constructs an `Ad` object
      *
@@ -36,7 +37,6 @@ export default class KijijiAd extends AdInfo {
     constructor(url: string, info: Partial<AdInfo> = {}, scraped=false) {
         super();
         let isScraped = scraped;
-        this.url = url;
 
         /* Updates ad properties with specified values */
         const updateInfo = (info: Partial<AdInfo>): void => {
@@ -48,9 +48,10 @@ export default class KijijiAd extends AdInfo {
             }
         };
         updateInfo(info);
+        this.url = url;
 
-        this.scrape = (callback?: (err: Error | null) => void): Promise<void> => {
-            const promise = scraper(this.url).then(newInfo => {
+        this.scrape = (options?: ScraperOptions, callback?: (err: Error | null) => void): Promise<void> => {
+            const promise = scrape(this.url, options).then(newInfo => {
                 updateInfo(newInfo);
                 isScraped = true;
             });
@@ -68,21 +69,22 @@ export default class KijijiAd extends AdInfo {
      * Creates an `Ad` by scraping the passed ad URL
      *
      * @param url Kijiji ad URL
+     * @param options Options to pass to the scraper
      * @param callback Called after the ad has been scraped. If an
      *                 error occurs during scraping, `err` will not
      *                 be `null`. If everything is successful, `ad`
      *                 will be an `Ad` object corresponding to `url`.
      * @returns `Promise` which resolves to an `Ad` corresponding to `url`
      */
-    static Get(url: string, callback?: (err: Error | null, ad: KijijiAd) => void): Promise<KijijiAd> {
-        const promise = scraper(url).then(function(info) {
-            return new KijijiAd(url, info, true);
+    static Get(url: string, options?: ScraperOptions, callback?: (err: Error | null, ad: Ad) => void): Promise<Ad> {
+        const promise = scrape(url, options).then(info => {
+            return new Ad(url, info, true);
         });
 
         if (callback) {
             promise.then(
                 ad => callback(null, ad),
-                err => callback(err, new KijijiAd(""))
+                err => callback(err, new Ad(""))
             );
         }
         return promise;
@@ -104,11 +106,12 @@ export default class KijijiAd extends AdInfo {
      * automatically, such as using the constructor or performing a
      * search with the `scrapeResultDetails` option set to `false`.
      *
+     * @param options Options to pass to the scraper
      * @param callback Called after the ad has been scraped. If an error
      *                 occurs during scraping, `err` will not be `null`.
      * @returns `Promise` that resolves once scraping has completed
      */
-    scrape: (callback?: (err: Error | null) => void) => Promise<void>;
+    scrape: (options?: ScraperOptions, callback?: (err: Error | null) => void) => Promise<void>;
 
     /**
      * Convert the ad to a string
@@ -138,4 +141,4 @@ export default class KijijiAd extends AdInfo {
         }
         return str;
     }
-}
+};

--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -1,0 +1,114 @@
+// api-scraper.ts
+/* Scrapes a Kijiji ad using the mobile API */
+
+import fetch from "node-fetch";
+import cheerio from "cheerio";
+
+import { API_REQUEST_HEADERS } from "../constants";
+import { cleanAdDescription, getLargeImageURL, isNumber } from "../helpers";
+import { AdInfo } from "../scraper";
+
+const AD_ID_REGEX = /\/(\d+)$/;
+const API_ADS_ENDPOINT = "https://mingle.kijiji.ca/api/ads";
+
+function castAttributeValue(item: CheerioElement, value: string): boolean | number | Date | string {
+    // Kijiji only returns strings for attributes. Convert to appropriate types
+    const type = (item.attribs.type || "").toLowerCase();
+    const localizedLabel = (item.attribs["localized-label"] || "").toLowerCase();
+    value = value.trim();
+
+    if (localizedLabel === "yes") {
+        return true;
+    } else if (localizedLabel === "no") {
+        return false;
+    } else if (isNumber(value)) {
+        return Number(value);
+    } else if (type === "date") {
+        return new Date(value);
+    }
+    return value;
+}
+
+/* Parses the XML of a Kijiji ad for its important information */
+function parseResponseXML(xml: string): AdInfo | null {
+    const $ = cheerio.load(xml);
+    const adElement = $("ad\\:ad").get();
+
+    if (adElement.length !== 1) {
+        return null;
+    }
+    return scrapeAdElement(adElement[0]);
+}
+
+export function scrapeAdElement(elem: CheerioElement): AdInfo | null {
+    const info = new AdInfo();
+
+    const $ = cheerio.load(elem);
+    const titleElem = $("ad\\:title");
+    const dateElem = $("ad\\:creation-date-time");
+
+    // We can reasonably expect these to be present
+    if (titleElem.length === 0 || dateElem.length === 0) {
+        return null;
+    }
+
+    info.title = titleElem.text();
+    info.description = cleanAdDescription($("ad\\:description").html() || "");
+    info.date = new Date(dateElem.text());
+
+    $("pic\\:picture pic\\:link[rel='normal']").each((_i, item) => {
+        const url = item.attribs.href;
+        if (url) {
+            info.images.push(getLargeImageURL(url));
+        }
+    });
+    info.image = info.images.length > 0 ? info.images[0] : "";
+
+
+    $("attr\\:attribute").each((_i, item) => {
+        const name = item.attribs.name;
+        const value = $(item).find("attr\\:value").text();
+        if (name && value) {
+            info.attributes[name] = castAttributeValue(item, value);
+        }
+    });
+
+    // Add other attributes of interest
+    // TODO: The API response contains much more. Worth a closer look.
+    const adPrice = $("ad\\:price types\\:amount").text();
+    if (isNumber(adPrice)) {
+        info.attributes["price"] = Number(adPrice);
+    }
+
+    const adLocation = $("ad\\:ad-address types\\:full-address").text();
+    if (adLocation) {
+        info.attributes["location"] = adLocation;
+    }
+
+    const adType = $("ad\\:ad-type ad\\:value").text();
+    if (adType) {
+        info.attributes["type"] = adType;
+    }
+
+    const viewCount = $("ad\\:view-ad-count").text();
+    if (viewCount) {
+        info.attributes["visits"] = Number(viewCount);
+    }
+    return info;
+}
+
+/* Queries the Kijiji mobile API for the ad at the passed URL */
+export function scrapeAPI(url: string): Promise<AdInfo | null> {
+    const adIdMatch = url.match(AD_ID_REGEX);
+    if (adIdMatch === null) {
+        throw new Error("Invalid Kijiji ad URL. Ad URLs must end in /some-ad-id.");
+    }
+
+    url = `${API_ADS_ENDPOINT}/${adIdMatch[1]}`;
+    // TODO: detect ban
+    return fetch(url, { headers: API_REQUEST_HEADERS, compress: true })
+        .then(res => res.text())
+        .then(body => {
+            return parseResponseXML(body);
+        });
+}

--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -4,7 +4,7 @@
 import fetch from "node-fetch";
 import cheerio from "cheerio";
 
-import { API_REQUEST_HEADERS } from "../constants";
+import { API_REQUEST_HEADERS, BANNED } from "../constants";
 import { cleanAdDescription, getLargeImageURL, isNumber } from "../helpers";
 import { AdInfo } from "../scraper";
 
@@ -105,9 +105,13 @@ export function scrapeAPI(url: string): Promise<AdInfo | null> {
     }
 
     url = `${API_ADS_ENDPOINT}/${adIdMatch[1]}`;
-    // TODO: detect ban
     return fetch(url, { headers: API_REQUEST_HEADERS, compress: true })
-        .then(res => res.text())
+        .then(res => {
+            if (res.status === 403) {
+                throw new Error(BANNED);
+            }
+            return res.text();
+        })
         .then(body => {
             return parseResponseXML(body);
         });

--- a/lib/backends/api-searcher.ts
+++ b/lib/backends/api-searcher.ts
@@ -1,0 +1,59 @@
+// api-searcher.ts
+/* Provides implementation for searcher which retrieves
+   results via the Kijiji mobile API */
+
+import cheerio from "cheerio";
+import qs from "querystring";
+import fetch from "node-fetch"
+
+import { Ad } from "../ad";
+import { scrapeAdElement } from "./api-scraper";
+import { API_REQUEST_HEADERS } from "../constants";
+import { PageResults, ResolvedSearchParameters } from "../search";
+
+const API_SEARCH_ENDPOINT = "https://mingle.kijiji.ca/api/ads";
+const LAST_PAGE_REGEX = /<types:link rel="next" href=".+"\/>/;
+
+function parseResultsXML(xml: string): Ad[] {
+    const adResults: Ad[] = [];
+    const $ = cheerio.load(xml);
+
+    // Get info for each ad
+    $("ad\\:ad").each((_i, item) => {
+        const url = $(item).find("ad\\:link[rel='self-public-website']").attr("href");
+        if (!url) {
+            throw new Error("Result ad has no URL");
+        }
+
+        const info = scrapeAdElement(item);
+        if (info === null) {
+            throw new Error("Result ad could not be parsed");
+        }
+        adResults.push(new Ad(url, info, true));
+    });
+
+    return adResults;
+}
+
+/**
+ * Searcher implementation
+ */
+export class APISearcher {
+    /* Retrieves one page of Kijiji search results */
+    getPageResults(params: ResolvedSearchParameters, pageNum: number): Promise<PageResults> {
+        const url = `${API_SEARCH_ENDPOINT}?${qs.stringify({
+            ...params,
+            page: pageNum - 1,
+            size: 20  // Results per page, just like the app
+        })}`;
+
+        // Search Kijiji
+        // TODO: detect ban
+        return fetch(url, { headers: API_REQUEST_HEADERS, compress: true })
+            .then(res => res.text())
+            .then(body => ({
+                pageResults: parseResultsXML(body),
+                isLastPage: body.match(LAST_PAGE_REGEX) === null
+            }));
+    }
+}

--- a/lib/backends/html-scraper.ts
+++ b/lib/backends/html-scraper.ts
@@ -4,7 +4,7 @@
 import fetch from "node-fetch";
 import cheerio from "cheerio";
 
-import { HTML_REQUEST_HEADERS } from "../constants";
+import { BANNED, HTML_REQUEST_HEADERS } from "../constants";
 import { cleanAdDescription, getLargeImageURL, isNumber } from "../helpers";
 import { AdInfo } from "../scraper";
 
@@ -77,9 +77,13 @@ function parseResponseHTML(html: string): AdInfo | null {
 
 /* Scrapes the page at the passed Kijiji ad URL */
 export function scrapeHTML(url: string): Promise<AdInfo | null> {
-    // TODO: detect ban
     return fetch(url, { headers: HTML_REQUEST_HEADERS })
-            .then(res => res.text())
+            .then(res => {
+                if (res.status === 403) {
+                    throw new Error(BANNED);
+                }
+                return res.text();
+            })
             .then(body => {
                 return parseResponseHTML(body);
             });

--- a/lib/backends/html-scraper.ts
+++ b/lib/backends/html-scraper.ts
@@ -1,0 +1,86 @@
+// html-scraper.ts
+/* Scrapes a Kijiji ad using the public-facing website */
+
+import fetch from "node-fetch";
+import cheerio from "cheerio";
+
+import { HTML_REQUEST_HEADERS } from "../constants";
+import { cleanAdDescription, getLargeImageURL, isNumber } from "../helpers";
+import { AdInfo } from "../scraper";
+
+function castAttributeValue(value: string): boolean | number | Date | string {
+    // Kijiji only returns strings. Convert to appropriate types
+    value = value.trim();
+
+    if (value.toLowerCase() === "true") {
+        return true;
+    } else if (value.toLowerCase() === "false") {
+        return false;
+    } else if (isNumber(value)) {
+        return Number(value);
+    } else if (!isNaN(Date.parse(value))) {
+        return new Date(value);
+    } else {
+        return value;
+    }
+}
+
+/* Parses the HTML of a Kijiji ad for its important information */
+function parseResponseHTML(html: string): AdInfo | null {
+    const info = new AdInfo();
+
+    // Kijiji is nice and gives us an object containing ad info
+    const $ = cheerio.load(html);
+    let adData: any = {};
+    let json = $("#FesLoader > script").text().replace("window.__data=", "");
+    json = json.substring(0, json.length - 1);  // Remove trailing semicolon
+
+    if (json.length === 0 || Object.keys(adData = JSON.parse(json)).length === 0 ||
+        !adData.hasOwnProperty("config") || !adData.config.hasOwnProperty("adInfo") ||
+        !adData.config.hasOwnProperty("VIP")) {
+        return null;
+    }
+
+    adData = adData.config;
+    info.title = adData.adInfo.title;
+    info.description = cleanAdDescription(adData.VIP.description || "");
+    info.date = new Date(adData.VIP.sortingDate);
+    info.image = getLargeImageURL(adData.adInfo.sharingImageUrl || "");
+
+    (adData.VIP.media || []).forEach((m: any) => {
+        if (m.type === "image" && m.href && typeof m.href === "string") {
+            info.images.push(getLargeImageURL(m.href));
+        }
+    });
+    (adData.VIP.adAttributes || []).forEach((a: any) => {
+        if (typeof a.machineKey === "string" && typeof a.machineValue === "string") {
+            info.attributes[a.machineKey] = castAttributeValue(a.machineValue);
+        }
+    });
+
+    // Add other attributes of interest
+    // TODO: This VIP object contains much more. Worth a closer look.
+    if (adData.VIP.price && typeof adData.VIP.price.amount === "number") {
+        info.attributes["price"] = adData.VIP.price.amount/100.0;
+    }
+    if (adData.VIP.adLocation) {
+        info.attributes["location"] = adData.VIP.adLocation;
+    }
+    if (adData.VIP.adType) {
+        info.attributes["type"] = adData.VIP.adType;
+    }
+    if (adData.VIP.visitCounter) {
+        info.attributes["visits"] = adData.VIP.visitCounter;
+    }
+    return info;
+}
+
+/* Scrapes the page at the passed Kijiji ad URL */
+export function scrapeHTML(url: string): Promise<AdInfo | null> {
+    // TODO: detect ban
+    return fetch(url, { headers: HTML_REQUEST_HEADERS })
+            .then(res => res.text())
+            .then(body => {
+                return parseResponseHTML(body);
+            });
+}

--- a/lib/backends/html-searcher.ts
+++ b/lib/backends/html-searcher.ts
@@ -1,0 +1,149 @@
+// html-searcher.ts
+/* Provides implementation for searcher which retrieves
+   results via the public-facing website */
+
+import cheerio from "cheerio";
+import qs from "querystring";
+import fetch, { Response as FetchResponse } from "node-fetch";
+
+import { Ad } from "../ad";
+import { AdInfo } from "../scraper";
+import { PageResults, ResolvedSearchParameters } from "../search";
+import { HTML_REQUEST_HEADERS } from "../constants";
+
+const KIJIJI_BASE_URL = "https://www.kijiji.ca";
+const KIJIJI_SEARCH_URL = KIJIJI_BASE_URL + "/b-search.html";
+const IMG_REGEX = /\/s\-l\d+\.jpg$/;
+const LOCATION_REGEX = /(.+)(\/.*)$/;
+
+/* Converts a date from a Kijiji ad result into a date object
+   (e.g., "< x hours ago", "yesterday", "dd/mm/yyyy") */
+   function dateFromRelativeDateString(dateString: string): Date {
+    if (dateString) {
+        dateString = dateString.toLowerCase().replace(/\//g, " ");
+
+        const split = dateString.split(" ");
+        const d = new Date();
+
+        if (split.length === 3) {
+            // dd/mm/yyyy format
+            d.setHours(0, 0, 0, 0);
+            d.setDate(parseInt(split[0]));
+            d.setMonth(parseInt(split[1]) - 1);
+            d.setFullYear(parseInt(split[2]));
+            return d;
+        } else if (split.length === 4) {
+            // "< x hours/minutes ago" format
+            const num = parseInt(split[1]);
+            const timeUnit = split[2];
+
+            if (timeUnit === "minutes") {
+                d.setMinutes(d.getMinutes() - num);
+                d.setSeconds(0, 0);
+            } else if (timeUnit === "hours") {
+                d.setHours(d.getHours() - num, 0, 0, 0);
+            }
+            return d;
+        } else if (dateString == "yesterday") {
+            d.setDate(d.getDate() - 1);
+            d.setHours(0, 0, 0, 0);
+            return d;
+        }
+    }
+    return new Date(NaN);
+}
+
+/* Extracts ad information from the HTML of a Kijiji ad results page */
+function parseResultsHTML(html: string): Ad[] {
+    const adResults: Ad[] = [];
+    const $ = cheerio.load(html);
+
+    // Get info for each ad
+    const allAdElements = $(".regular-ad");
+    const filteredAdElements = allAdElements.not(".third-party");
+
+    filteredAdElements.each((_i, item) => {
+        const path = $(item).find("a.title").attr("href");
+        const url = KIJIJI_BASE_URL + path;
+        const info: Partial<AdInfo> = {
+            title: $(item).find("a.title").text().trim(),
+
+            image: (
+                // `data-src` contains the URL of the image to lazy load
+                //
+                // `src` starts off with a placeholder image and will
+                // remain if the ad has no image
+                $(item).find(".image img").data("src") || $(item).find(".image img").attr("src") || ""
+            ).replace(IMG_REGEX, "/s-l2000.jpg"),
+
+            date: dateFromRelativeDateString(
+                // For some reason, some categories (like anything under
+                // SERVICES) use different markup than usual
+                //
+                // The string split is needed to handle:
+                //
+                // <td class="posted">
+                //    Some date
+                //    <br>
+                //    Some location
+                // </td>
+                //
+                // AKA "Some date\nSome location"
+                ($(item).find(".date-posted").text() || $(item).find(".posted").text()).trim().split("\n")[0]
+            ),
+
+            // Pick a format, Kijiji
+            description: ($(item).find(".description > p").text() || $(item).find(".description").text()).trim()
+        };
+
+        if (!path) {
+            throw new Error("Result ad has no URL");
+        }
+
+        adResults.push(new Ad(url, info));
+    });
+    return adResults;
+}
+
+/**
+ * Searcher implementation
+ */
+export class HTMLSearcher {
+    private firstResultPageURL: string | undefined = undefined;
+
+    /* Retrieves the URL of the first page of search results */
+    private async getFirstResultPageURL(params: ResolvedSearchParameters): Promise<string> {
+        if (this.firstResultPageURL === undefined) {
+            const res: FetchResponse = await fetch(
+                `${KIJIJI_SEARCH_URL}?${qs.stringify(params)}`,
+                { headers: HTML_REQUEST_HEADERS }
+            );
+
+            // Kijiji will redirect to the rendered results
+            // Grab the destination path so that it can be modified for pagination
+            if (res.status !== 200 || !res.url) {
+                // TODO: detect ban and show a different message
+                throw new Error("Kijiji failed to redirect to results page");
+            }
+            this.firstResultPageURL = res.url;
+        }
+
+        return this.firstResultPageURL;
+    }
+
+    /* Retrieves one page of Kijiji search results */
+    async getPageResults(params: ResolvedSearchParameters, pageNum: number): Promise<PageResults> {
+        const firstResultPageURL = await this.getFirstResultPageURL(params);
+
+        // Specify page number. It must be the last path component of the URL
+        const url = firstResultPageURL.replace(LOCATION_REGEX, `$1/page-${pageNum}$2`);
+
+        // Search Kijiji
+        return fetch(url, { headers: HTML_REQUEST_HEADERS })
+            .then(res => res.text())
+            .then(body => ({
+                pageResults: parseResultsHTML(body),
+                isLastPage: body.indexOf('"isLastPage":true') !== -1
+            }));
+    }
+}

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -1,0 +1,311 @@
+jest.mock("node-fetch");
+
+import fetch from "node-fetch";
+import { scrapeAPI as scraper } from "../api-scraper";
+import * as helpers from "../../helpers";
+
+const FAKE_VALID_AD_URL = "http://example.com/ad/123";
+
+describe("Ad API scraper", () => {
+    const fetchSpy = fetch as any as jest.Mock;
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const mockResponse = (body: string) => {
+        fetchSpy.mockResolvedValue({
+            text: () => body
+        });
+    };
+
+    type MockAdInfo = {
+        title?: string;
+        description?: string;
+        date?: Date;
+        images?: string[];
+        attributes?: any,
+        price?: string;
+        location?: string;
+        type?: string;
+        visits?: number;
+    };
+
+    const validateRequest = () => {
+        expect(fetchSpy).toBeCalledWith(
+            "https://mingle.kijiji.ca/api/ads/123",
+            { compress: true, headers: {
+                "User-Agent": "com.ebay.kijiji.ca 6.5.0 (samsung SM-G930U; Android 8.0.0; en_US)",
+                "Accept-Language": "en-CA",
+                Accept: "application/xml",
+                Connection: "close",
+                Pragma: "no-cache",
+                Authorization: "Basic Y2FfYW5kcm9pZF9hcHA6YXBwQ2xAc3NpRmllZHMh",
+                Host: "mingle.kijiji.ca",
+                "Accept-Encoding": "gzip, deflate"
+            }}
+        );
+    }
+
+    const serializeAttribute = (name: string, value: any) => {
+        return `
+            <attr:attribute
+                name="${name}"
+                ${typeof value === "boolean" ? `localized-label=${value ? "Yes" : "No"}` : ""}
+                ${value instanceof Date ? 'type="DATE"' : ""}
+            >
+                ${value !== undefined ?
+                    `
+                        <attr:value>
+                        ${
+                            value instanceof Date ? value.toISOString() :
+                            typeof value === "string" ? value :
+                            Number(value)
+                        }
+                        </attr:value>
+                    `
+                    : ""
+                }
+            </attr:attribute>
+        `;
+    };
+
+    const createAdXML = (info: MockAdInfo) => {
+        return `
+            <ad:ad>
+                ${info.title ? `<ad:title>${info.title}</ad:title>` : ""}
+                ${info.description ? `<ad:description>${info.description}</ad:description>` : ""}
+                ${info.date ? `<ad:creation-date-time>${info.date.toISOString()}</ad:creation-date-time>` : ""}
+                <pic:pictures>
+                    ${(info.images ? info.images.map(url => `<pic:picture><pic:link rel="normal" href="${url}"></pic:picture>`) : []).join("\n")}
+                </pic:pictures>
+                ${info.price ? `<ad:price><types:amount>${info.price}</types:amount></ad:price>` : ""}
+                ${info.location ? `<ad:ad-address><types:full-address>${info.location}</types:full-address></ad:ad-address>` : ""}
+                ${info.type ? `<ad:ad-type><ad:value>${info.type}</ad:value></ad:ad-type>` : ""}
+                ${info.visits ? `<ad:view-ad-count>${info.visits}</ad:view-ad-count>` : ""}
+                <attr:attributes>
+                    ${info.attributes ? Object.entries(info.attributes).map(e => serializeAttribute(e[0], e[1])) : ""}
+                </attr:attributes>
+            </ad:ad>
+        `;
+    };
+
+    it("should fail with invalid URL", async () => {
+        try {
+            await scraper("http://example.com")
+            fail("Expected error for invalid URL");
+        } catch (err) {
+            expect(err.message).toBe("Invalid Kijiji ad URL. Ad URLs must end in /some-ad-id.");
+        }
+    });
+
+    it.each`
+        test                     | xml
+        ${"Bad markup"}          | ${"Bad markup"}
+        ${"Missing title"}       | ${createAdXML({})}
+        ${"Missing date"}        | ${createAdXML({ title: "My ad title" })}
+    `("should fail to scrape invalid XML ($test)", async ({ xml }) => {
+        mockResponse(xml);
+
+        const adInfo = await scraper(FAKE_VALID_AD_URL);
+        validateRequest();
+        expect(adInfo).toBeNull();
+    });
+
+    describe("valid markup", () => {
+        it("should scrape title", async () => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date()
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.title).toBe("My ad title");
+        });
+
+        it.each`
+            test         | description            | expected
+            ${"missing"} | ${undefined}           | ${""}
+            ${"present"} | ${"My ad description"} | ${"My ad description"}
+        `("should scrape description ($test)", async ({ description, expected }) => {
+            const cleanAdDescriptionSpy = jest.spyOn(helpers, "cleanAdDescription");
+            cleanAdDescriptionSpy.mockReturnValueOnce("Clean description");
+
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description,
+                date: new Date()
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(cleanAdDescriptionSpy).toBeCalledWith(expected);
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.description).toBe("Clean description");
+
+            cleanAdDescriptionSpy.mockRestore();
+        });
+
+        it("should scrape date", async () => {
+            const date = new Date();
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.date).toEqual(date);
+        });
+
+        it.each`
+            test                 | urls                    | expectedURL
+            ${"no images"}       | ${undefined}            | ${""}
+            ${"empty images"}    | ${[]}                   | ${""}
+            ${"one image"}       | ${["image1"]}           | ${"image1"}
+            ${"multiple images"} | ${["image1", "image2"]} | ${"image1"}
+        `("should scrape image ($test)", async ({ urls, expectedURL }) => {
+            const getLargeImageURLSpy = jest.spyOn(helpers, "getLargeImageURL");
+            getLargeImageURLSpy.mockImplementation(url => url + "_large");
+
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                images: urls
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.image).toBe(expectedURL ? expectedURL + "_large" : expectedURL);
+
+            getLargeImageURLSpy.mockRestore();
+        });
+
+        it("should scrape images", async () => {
+            const getLargeImageURLSpy = jest.spyOn(helpers, "getLargeImageURL");
+            getLargeImageURLSpy.mockImplementation(url => url + "_large");
+
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                images: [
+                    // Invalid,
+                    "",
+
+                    // Valid
+                    "http://example.com/image",
+                    "http://example.com/images/$_12.JPG",
+                    "http://example.com/images/$_34.PNG"
+                ]
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(getLargeImageURLSpy).toBeCalledTimes(3);
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.images).toEqual([
+                "http://example.com/image_large",
+                "http://example.com/images/$_12.JPG_large",
+                "http://example.com/images/$_34.PNG_large"
+            ]);
+
+            getLargeImageURLSpy.mockRestore();
+        });
+
+        it.each`
+            test               | value
+            ${"undefined"}     | ${undefined}
+            ${"true boolean"}  | ${true}
+            ${"false boolean"} | ${false}
+            ${"integer"}       | ${123}
+            ${"float"}         | ${1.21}
+            ${"date"}          | ${new Date("2020-09-06T20:52:47.474Z")}
+            ${"string"}        | ${"hello"}
+        `("should scrape attribute ($test)", async ({ value }) => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                attributes: {
+                    myAttr: value
+                }
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes).toEqual({
+                myAttr: value
+            });
+        });
+
+        it.each`
+            test                    | value        | expected
+            ${"no amount"}          | ${undefined} | ${undefined}
+            ${"non-numeric amount"} | ${"abc"}     | ${undefined}
+            ${"with amount"}        | ${1.23}      | ${1.23}
+        `("should scrape price ($test)", async ({ value, expected }) => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                price: value
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.price).toBe(expected);
+        });
+
+        it("should scrape location", async () => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                location: "Some location"
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.location).toBe("Some location");
+        });
+
+        it("should scrape type", async () => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                type: "Some type"
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.type).toBe("Some type");
+        });
+
+        it("should scrape visits", async () => {
+            mockResponse(createAdXML({
+                title: "My ad title",
+                description: "My ad description",
+                date: new Date(),
+                visits: 12345
+            }));
+
+            const adInfo = await scraper(FAKE_VALID_AD_URL);
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.visits).toBe(12345);
+        });
+    });
+});

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -90,6 +90,23 @@ describe("Ad API scraper", () => {
         `;
     };
 
+    it("should detect ban", async () => {
+        fetchSpy.mockResolvedValue({ status: 403 });
+
+        try {
+            await scraper(FAKE_VALID_AD_URL);
+            fail("Expected error for ban");
+        } catch (err) {
+            expect(err.message).toBe(
+                "Kijiji denied access. You are likely temporarily blocked. This " +
+                "can happen if you scrape too aggressively. Try scraping again later, " +
+                "and more slowly. If this happens even when scraping reasonably, please " +
+                "open an issue at: https://github.com/mwpenny/kijiji-scraper/issues"
+            )
+            validateRequest();
+        }
+    });
+
     it("should fail with invalid URL", async () => {
         try {
             await scraper("http://example.com")

--- a/lib/backends/test/api-searcher.spec.ts
+++ b/lib/backends/test/api-searcher.spec.ts
@@ -70,6 +70,23 @@ describe("Search result API scraper", () => {
         page: 0,
         size: 20
     };
+
+    it("should detect ban", async () => {
+        fetchSpy.mockResolvedValue({ status: 403 });
+
+        try {
+            await search();
+            fail("Expected error for ban");
+        } catch (err) {
+            expect(err.message).toBe(
+                "Kijiji denied access. You are likely temporarily blocked. This " +
+                "can happen if you scrape too aggressively. Try scraping again later, " +
+                "and more slowly. If this happens even when scraping reasonably, please " +
+                "open an issue at: https://github.com/mwpenny/kijiji-scraper/issues"
+            )
+        }
+    });
+
     describe("search parameters", () => {
         it("should pass all defined params in search URL", async () => {
             const params = {
@@ -97,7 +114,11 @@ describe("Search result API scraper", () => {
                 await search();
                 fail("Expected error while scraping results page");
             } catch (err) {
-                expect(err.message).toBe("Result ad has no URL");
+                expect(err.message).toBe(
+                    "Result ad has no URL. It is possible that Kijiji changed their " +
+                    "markup. If you believe this to be the case, please open an issue " +
+                    "at: https://github.com/mwpenny/kijiji-scraper/issues"
+                );
                 validateRequestHeaders();
                 expect(scrapeSpy).not.toBeCalled();
             }
@@ -110,7 +131,11 @@ describe("Search result API scraper", () => {
                 await search();
                 fail("Expected error while scraping results page");
             } catch (err) {
-                expect(err.message).toBe("Result ad could not be parsed");
+                expect(err.message).toBe(
+                    "Result ad could not be parsed. It is possible that Kijiji " +
+                    "changed their markup. If you believe this to be the case, " +
+                    "please open an issue at: https://github.com/mwpenny/kijiji-scraper/issues"
+                );
                 validateRequestHeaders();
                 expect(scrapeSpy).toBeCalled();
             }

--- a/lib/backends/test/api-searcher.spec.ts
+++ b/lib/backends/test/api-searcher.spec.ts
@@ -1,0 +1,180 @@
+jest.mock("node-fetch");
+
+import cheerio from "cheerio";
+import fetch from "node-fetch";
+import qs from "querystring";
+import * as apiScraper from "../api-scraper";
+import { ResolvedSearchParameters, SearchParameters } from "../../search";
+import { APISearcher } from "../api-searcher";
+
+describe("Search result API scraper", () => {
+    const fetchSpy = fetch as any as jest.Mock;
+    const scrapeSpy = jest.spyOn(apiScraper, "scrapeAdElement");
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    type MockAdInfo = {
+        url?: string;
+        title?: string;
+        date?: Date;
+    };
+
+    const createAdXML = (info: MockAdInfo) => {
+        return `
+            <ad:ad>
+                ${info.url ? `<ad:link rel="self-public-website" href="${info.url}"></ad:link>` : ""}
+                ${info.title ? `<ad:title>${info.title}</ad:title>` : ""}
+                ${info.date ? `<ad:creation-date-time>${info.date.toISOString()}</ad:creation-date-time>` : ""}
+            </ad:ad>
+        `;
+    };
+
+    const search = (params: ResolvedSearchParameters = { locationId: 0, categoryId: 0}) => {
+        return new APISearcher().getPageResults(params, 1);
+    };
+
+    const validateSearchUrl = (url: string, expectedParams: SearchParameters) => {
+        const splitUrl = url.split("?");
+        expect(splitUrl.length).toBe(2);
+        expect(splitUrl[0]).toBe("https://mingle.kijiji.ca/api/ads")
+        expect(qs.parse(splitUrl[1])).toEqual(qs.parse(qs.stringify(expectedParams)));
+    };
+
+    const validateRequestHeaders = () => {
+        expect(fetchSpy).toBeCalled();
+        for (const call of fetchSpy.mock.calls) {
+            expect(call).toEqual([
+                expect.any(String),
+                {
+                    headers: {
+                        "User-Agent": "com.ebay.kijiji.ca 6.5.0 (samsung SM-G930U; Android 8.0.0; en_US)",
+                        "Accept-Language": "en-CA",
+                        Accept: "application/xml",
+                        Connection: "close",
+                        Pragma: "no-cache",
+                        Authorization: "Basic Y2FfYW5kcm9pZF9hcHA6YXBwQ2xAc3NpRmllZHMh",
+                        Host: "mingle.kijiji.ca",
+                        "Accept-Encoding": "gzip, deflate"
+                    },
+                    compress: true
+                }
+            ]);
+        };
+    }
+
+    const defaultSearchParams: SearchParameters = {
+        locationId: 0,
+        categoryId: 0,
+        page: 0,
+        size: 20
+    };
+    describe("search parameters", () => {
+        it("should pass all defined params in search URL", async () => {
+            const params = {
+                ...defaultSearchParams,
+                locationId: 123,
+                categoryId: 456,
+                someOtherParam: "hello",
+                undef: undefined
+            };
+
+            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+
+            await search(params);
+
+            validateRequestHeaders();
+            validateSearchUrl(fetchSpy.mock.calls[0][0], params);
+        });
+    });
+
+    describe("result page scraping", () => {
+        it("should throw error if results page is invalid", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createAdXML({}) });
+
+            try {
+                await search();
+                fail("Expected error while scraping results page");
+            } catch (err) {
+                expect(err.message).toBe("Result ad has no URL");
+                validateRequestHeaders();
+                expect(scrapeSpy).not.toBeCalled();
+            }
+        });
+
+        it("should throw error if scraping fails", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createAdXML({ url: "http://example.com" }) });
+
+            try {
+                await search();
+                fail("Expected error while scraping results page");
+            } catch (err) {
+                expect(err.message).toBe("Result ad could not be parsed");
+                validateRequestHeaders();
+                expect(scrapeSpy).toBeCalled();
+            }
+        });
+
+        it("should scrape each result ad", async () => {
+            const ad1Info = {
+                url: "http://example.com/1",
+                title: "Ad 1",
+                date: new Date(123)
+            };
+            const ad2Info = {
+                url: "http://example.com/2",
+                title: "Ad 2",
+                date: new Date(456)
+            };
+            const ad1 = createAdXML(ad1Info).trim();
+            const ad2 = createAdXML(ad2Info).trim();
+
+            fetchSpy.mockResolvedValueOnce({ text: () =>  ad1 + ad2 });
+
+            const { pageResults } = await search();
+
+            validateRequestHeaders();
+
+            expect(scrapeSpy).toBeCalledTimes(2);
+            expect(cheerio.load(scrapeSpy.mock.calls[0][0]).html()).toBe(ad1);
+            expect(cheerio.load(scrapeSpy.mock.calls[1][0]).html()).toBe(ad2);
+
+            expect(pageResults).toEqual([
+                expect.objectContaining(ad1Info),
+                expect.objectContaining(ad2Info)
+            ]);
+            expect(pageResults[0].isScraped()).toBe(true);
+            expect(pageResults[1].isScraped()).toBe(true);
+        });
+
+        it.each`
+            isLastPage
+            ${true}
+            ${false}
+        `("should detect last page (isLastPage=$isLastPage)", async ({ isLastPage }) => {
+            let mockResponse = createAdXML({
+                url: "http://example.com",
+                title: "My ad",
+                date: new Date()
+            });
+            if (!isLastPage) {
+                mockResponse += '<types:link rel="next" href="http://example.com/nextpage"/>';
+            }
+            fetchSpy.mockResolvedValueOnce({ text: () => mockResponse });
+
+            const result = await search();
+            validateRequestHeaders();
+            expect(result.pageResults.length).toBe(1);
+            expect(result.isLastPage).toBe(isLastPage);
+        });
+
+        it("should handle empty response", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults.length).toBe(0);
+        });
+    });
+});

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -1,0 +1,284 @@
+jest.mock("node-fetch");
+
+import fetch from "node-fetch";
+import * as helpers from "../../helpers";
+import { scrapeHTML as scraper } from "../html-scraper";
+
+describe("Ad HTML scraper", () => {
+    const fetchSpy = fetch as any as jest.Mock;
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const mockResponse = (body: string) => {
+        fetchSpy.mockResolvedValue({
+            text: () => body
+        });
+    };
+
+    const validateRequest = () => {
+        expect(fetchSpy).toBeCalledWith(
+            "http://example.com",
+            {
+                headers: {
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0"
+                }
+            }
+        );
+    };
+
+    const createAdHTML = (info: any) => {
+        return `
+            <html>
+                <body>
+                    <div id="FesLoader">
+                        <script type="text/javascript">window.__data=${JSON.stringify(info)};</script>
+                    </div>
+                </body>
+            </html>
+        `;
+    };
+
+    it.each`
+        test                         | html
+        ${"Bad markup"}              | ${"Bad markup"}
+        ${"Missing FesLoader"}       | ${"<html></html>"}
+        ${"Empty FesLoader"}         | ${createAdHTML({})}
+        ${"Missing config property"} | ${createAdHTML({ abc: 123 })}
+        ${"Missing adInfo property"} | ${createAdHTML({ config: {} })}
+        ${"Missing VIP property"}    | ${createAdHTML({ config: { adInfo: {} } })}
+    `("should fail to scrape invalid HTML ($test)", async ({ html }) => {
+        mockResponse(html);
+
+        const adInfo = await scraper("http://example.com");
+        validateRequest();
+        expect(adInfo).toBeNull();
+    });
+
+    describe("valid markup", () => {
+        it("should scrape title", async () => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {
+                        title: "My ad title"
+                    },
+                    VIP: {}
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.title).toBe("My ad title");;
+        });
+
+        it.each`
+            test         | description            | expected
+            ${"missing"} | ${undefined}           | ${""}
+            ${"present"} | ${"My ad description"} | ${"My ad description"}
+        `("should scrape description ($test)", async ({ description, expected }) => {
+            const cleanAdDescriptionSpy = jest.spyOn(helpers, "cleanAdDescription");
+            cleanAdDescriptionSpy.mockReturnValueOnce("Clean description");
+
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        description
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(cleanAdDescriptionSpy).toBeCalledWith(expected);
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.description).toBe("Clean description");
+
+            cleanAdDescriptionSpy.mockRestore();
+        });
+
+        it("should scrape date", async () => {
+            const date = new Date();
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        sortingDate: date
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.date).toEqual(date);
+        });
+
+        it("should scrape image", async () => {
+            const getLargeImageURLSpy = jest.spyOn(helpers, "getLargeImageURL");
+            getLargeImageURLSpy.mockReturnValueOnce("large image URL");
+
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {
+                        sharingImageUrl: "some image URL"
+                    },
+                    VIP: {}
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(getLargeImageURLSpy).toBeCalledWith("some image URL");
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.image).toBe("large image URL");
+
+            getLargeImageURLSpy.mockRestore();
+        });
+
+        it("should scrape images", async () => {
+            const getLargeImageURLSpy = jest.spyOn(helpers, "getLargeImageURL");
+            getLargeImageURLSpy.mockImplementation(url => url + "_large");
+
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        media: [
+                            // Invalid
+                            { type: "not-an-image", href: "http://example.org" },
+                            { type: "image", href: "" },
+                            { type: "image", href: 123 },
+                            { type: "image" },
+
+                            // Valid
+                            { type: "image", href: "http://example.com/image" },
+                            { type: "image", href: "http://example.com/images/$_12.JPG" },
+                            { type: "image", href: "http://example.com/images/$_34.PNG" },
+                        ]
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(getLargeImageURLSpy).toBeCalledTimes(4);  // +1 for sharingImageUrl (empty)
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.images).toEqual([
+                "http://example.com/image_large",
+                "http://example.com/images/$_12.JPG_large",
+                "http://example.com/images/$_34.PNG_large"
+            ]);
+
+            getLargeImageURLSpy.mockRestore();
+        });
+
+        it.each`
+            test               | value                         | expectedValue
+            ${"true boolean"}  | ${"true"}                     | ${true}
+            ${"false boolean"} | ${"false"}                    | ${false}
+            ${"integer"}       | ${"123"}                      | ${123}
+            ${"float"}         | ${"1.21"}                     | ${1.21}
+            ${"date"}          | ${"2020-09-06T20:52:47.474Z"} | ${new Date("2020-09-06T20:52:47.474Z")}
+            ${"string"}        | ${"hello"}                    | ${"hello"}
+        `("should scrape attribute ($test)", async ({ value, expectedValue }) => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        adAttributes: [
+                            // Invalid
+                            {},
+                            { machineKey: 123 },
+                            { machineValue: 456 },
+                            { machineKey: 123, machineValue: 456 },
+                            { machineKey: "invalid", machineValue: 456 },
+                            { machineKey: 123, machineValue: "invalid" },
+
+                            // Valid
+                            { machineKey: "myAttr", machineValue: value }
+                        ]
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes).toEqual({
+                myAttr: expectedValue
+            });
+        });
+
+        it.each`
+            test                    | value                | expected
+            ${"no amount"}          | ${null}              | ${undefined}
+            ${"non-numeric amount"} | ${{ amount: "abc" }} | ${undefined}
+            ${"with amount"}        | ${{ amount: 123 }}   | ${1.23}
+        `("should scrape price ($test)", async ({ value, expected }) => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        price: value
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.price).toBe(expected);
+        });
+
+        it("should scrape location", async () => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        adLocation: "Some location"
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.location).toBe("Some location");
+        });
+
+        it("should scrape type", async () => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        adType: "Some type"
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.type).toBe("Some type");
+        });
+
+        it("should scrape visits", async () => {
+            mockResponse(createAdHTML({
+                config: {
+                    adInfo: {},
+                    VIP: {
+                        visitCounter: 12345
+                    }
+                }
+            }));
+
+            const adInfo = await scraper("http://example.com");
+            validateRequest();
+            expect(adInfo).not.toBeNull();
+            expect(adInfo!.attributes.visits).toBe(12345);
+        });
+    });
+});

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -40,6 +40,23 @@ describe("Ad HTML scraper", () => {
         `;
     };
 
+    it("should detect ban", async () => {
+        fetchSpy.mockResolvedValue({ status: 403 });
+
+        try {
+            await scraper("http://example.com");
+            fail("Expected error for ban");
+        } catch (err) {
+            expect(err.message).toBe(
+                "Kijiji denied access. You are likely temporarily blocked. This " +
+                "can happen if you scrape too aggressively. Try scraping again later, " +
+                "and more slowly. If this happens even when scraping reasonably, please " +
+                "open an issue at: https://github.com/mwpenny/kijiji-scraper/issues"
+            )
+            validateRequest();
+        }
+    });
+
     it.each`
         test                         | html
         ${"Bad markup"}              | ${"Bad markup"}

--- a/lib/backends/test/html-searcher.spec.ts
+++ b/lib/backends/test/html-searcher.spec.ts
@@ -1,0 +1,363 @@
+jest.mock("node-fetch");
+
+import fetch from "node-fetch";
+import qs from "querystring";
+import { ResolvedSearchParameters, SearchParameters } from "../../search";
+import { HTMLSearcher } from "../html-searcher";
+
+type ResultInfo = {
+    isFeatured: boolean;
+    isThirdParty: boolean;
+    title: string;
+    path: string;
+    description: string;
+    imageAttributes: string;
+    datePosted: string;
+};
+
+const defaultResultInfo: ResultInfo = {
+    isFeatured: false,
+    isThirdParty: false,
+    title: "",
+    path: "/someAd",
+    description: "",
+    imageAttributes: "",
+    datePosted: ""
+};
+
+// Result pages in most categories use this markup
+const createStandardResultHTML = (info: Partial<ResultInfo>): string => {
+    info = { ...defaultResultInfo, ...info };
+
+    return `
+        <div class="search-item
+            ${info.isFeatured ? "top-feature" : "regular-ad"}
+            ${info.isThirdParty ? "third-party" : ""}">
+            <div class="clearfix">
+                <div class="left-col">
+                    <div class="image">
+                        <picture><img ${info.imageAttributes}></picture>
+                    </div>
+
+                    <div class="info">
+                        <div class="info-container">
+                            <div class="title">
+                                <a class="title" href="${info.path}">${info.title}</a>
+                            </div>
+
+                            <div class="location">
+                                <span class="">Some location</span>
+                                <span class="date-posted">${info.datePosted}</span>
+                            </div>
+
+                            <div class="description">${info.description}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+};
+
+// For some reason, some categories (like anything under
+// SERVICES) use different markup classes than usual
+const createServiceResultHTML = (info: Partial<ResultInfo>): string => {
+    info = { ...defaultResultInfo, ...info };
+
+    return `
+        <table class="
+            ${info.isFeatured ? "top-feature" : "regular-ad"}
+            ${info.isThirdParty ? "third-party" : ""}">
+            <tbody>
+                <tr>
+                    <td class="description">
+                        <a class="title" href="${info.path}">${info.title}</a>
+                        <p>${info.description}</p>
+                    </td>
+
+                    <td class="image">
+                        <div class="multiple-images">
+                            <picture><img ${info.imageAttributes}></picture>
+                        </div>
+                    </td>
+
+                    <td class="posted">
+                        ${info.datePosted}<br>
+                        Some location
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+};
+
+describe.each`
+    markup                           | createResultHTML
+    ${"standard result page markup"} | ${createStandardResultHTML}
+    ${"service result page markup"}  | ${createServiceResultHTML}
+`("Search result HTML scraper ($markup)", ({ createResultHTML }) => {
+    const fetchSpy = fetch as any as jest.Mock;
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const validateSearchUrl = (url: string, expectedParams: SearchParameters) => {
+        const splitUrl = url.split("?");
+        expect(splitUrl.length).toBe(2);
+        expect(splitUrl[0]).toBe("https://www.kijiji.ca/b-search.html")
+        expect(qs.parse(splitUrl[1])).toEqual(qs.parse(qs.stringify(expectedParams)));
+    };
+
+    const validateRequestHeaders = () => {
+        expect(fetchSpy).toBeCalled();
+        for (const call of fetchSpy.mock.calls) {
+            expect(call).toEqual([
+                expect.any(String),
+                {
+                    headers: {
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0"
+                    }
+                }
+            ]);
+        };
+    }
+
+    const search = (params: ResolvedSearchParameters = { locationId: 0, categoryId: 0}) => {
+        return new HTMLSearcher().getPageResults(params, 1);
+    };
+
+    const defaultSearchParams: SearchParameters = {
+        locationId: 0,
+        categoryId: 0,
+        formSubmit: true,
+        siteLocale: "en_CA"
+    };
+    describe("search parameters", () => {
+        it("should pass all defined params in search URL", async () => {
+            const params = {
+                ...defaultSearchParams,
+                locationId: 123,
+                categoryId: 456,
+                someOtherParam: "hello",
+                undef: undefined
+            };
+
+            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
+            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+
+            await search(params);
+
+            validateRequestHeaders();
+            validateSearchUrl(fetchSpy.mock.calls[0][0], params);
+        });
+    });
+
+    describe("result page redirect", () => {
+        it.each`
+            test                       | response
+            ${"non-200 response code"} | ${{ status: 418 }}
+            ${"no redirect"}           | ${{ status: 200 }}
+        `("should throw error for bad response ($test)", async ({ response }) => {
+            fetchSpy.mockResolvedValue(response);
+
+            try {
+                await search();
+                fail("Expected error for non-200 response code");
+            } catch (err) {
+                expect(err.message).toBe("Kijiji failed to redirect to results page");
+                validateRequestHeaders();
+            }
+        });
+
+        it("should be used for pagination", async () => {
+            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
+
+            const searcher = new HTMLSearcher();
+            await searcher.getPageResults({ locationId: 0, categoryId: 0 }, 1);
+            await searcher.getPageResults({ locationId: 0, categoryId: 0 }, 2);
+
+            expect(fetchSpy).toBeCalledTimes(3);
+            validateRequestHeaders();
+
+            // Only the first request should include the paramaters since
+            // the searcher instance is re-used for subsequent requests
+            validateSearchUrl(fetchSpy.mock.calls[0][0], { locationId: 0, categoryId: 0});
+            expect(fetchSpy.mock.calls[1][0]).toBe("http://example.com/search/page-1/results");
+            expect(fetchSpy.mock.calls[2][0]).toBe("http://example.com/search/page-2/results");
+        });
+    });
+
+    describe("result page scraping", () => {
+        // Helpers for date tests
+        const nanDataValidator = (date: Date) => {
+            expect(Number.isNaN(date.getTime())).toBe(true);
+        };
+        const makeSpecificDateValidator = (month: number, day: number, year: number) => {
+            return (date: Date) => {
+                const d = new Date();
+                d.setMonth(month - 1);
+                d.setDate(day);
+                d.setFullYear(year);
+                d.setHours(0, 0, 0, 0);
+
+                expect(date).toEqual(d);
+            }
+        };
+        const makeMinutesAgoValidator = (minutes: number) => {
+            return (date: Date) => {
+                const minutesAgo = new Date();
+                minutesAgo.setMinutes(minutesAgo.getMinutes() - minutes, 0, 0);
+
+                expect(date).toEqual(minutesAgo);
+            }
+        };
+        const makeHoursAgoValidator = (hours: number) => {
+            return (date: Date) => {
+                const hoursAgo = new Date();
+                hoursAgo.setHours(hoursAgo.getHours() - hours, 0, 0, 0);
+
+                expect(date).toEqual(hoursAgo);
+            }
+        };
+        const makeDaysAgoValidator = (days: number) => {
+            return (date: Date) => {
+                const daysAgo = new Date();
+                daysAgo.setDate(daysAgo.getDate() - days);
+                daysAgo.setHours(0, 0, 0, 0);
+
+                expect(date).toEqual(daysAgo);
+            }
+        };
+        const nowIshValidator = (date: Date) => {
+            const nowIsh = new Date();
+            nowIsh.setSeconds(date.getSeconds());
+            nowIsh.setMilliseconds(date.getMilliseconds());
+
+            expect(date).toEqual(nowIsh);
+        };
+
+        beforeEach(() => {
+            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
+        });
+
+        it("should throw error if results page is invalid", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ path: "" }) });
+
+            try {
+                await search();
+                fail("Expected error while scraping results page");
+            } catch (err) {
+                expect(err.message).toBe("Result ad has no URL");
+                validateRequestHeaders();
+            }
+        });
+
+        it("should scrape title", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ title: "My title" }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults).toEqual([expect.objectContaining({
+                title: "My title"
+            })]);
+        });
+
+        it.each`
+            test                    | imageAttributes                   | expectedValue
+            ${"with data-src"}      | ${'data-src="/image" src="blah"'} | ${"/image"}
+            ${"with src"}           | ${'data-src="" src="/image"'}     | ${"/image"}
+            ${"with no attributes"} | ${""}                             | ${""}
+            ${"upsize"}             | ${'src="/image/s-l123.jpg"'}      | ${"/image/s-l2000.jpg"}
+        `("should scrape image ($test)", async ({ imageAttributes, expectedValue }) => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ imageAttributes }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults).toEqual([expect.objectContaining({
+                image: expectedValue
+            })]);
+        });
+
+        it.each`
+            test             | datePosted           | validator
+            ${"no date"}     | ${""}                | ${nanDataValidator}
+            ${"invalid"}     | ${"invalid"}         | ${nanDataValidator}
+            ${"dd/mm/yyyy"}  | ${"7/9/2020"}        | ${makeSpecificDateValidator(9, 7, 2020)}
+            ${"minutes ago"} | ${"< 5 minutes ago"} | ${makeMinutesAgoValidator(5)}
+            ${"hours ago"}   | ${"< 2 hours ago"}   | ${makeHoursAgoValidator(2)}
+            ${"invalid ago"} | ${"< 1 parsec ago"}  | ${nowIshValidator}
+            ${"yesterday"}   | ${"yesterday"}       | ${makeDaysAgoValidator(1)}
+        `("should scrape date ($test)", async ({ datePosted, validator }) => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ datePosted }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults.length).toBe(1);
+            validator(pageResults[0].date);
+        });
+
+        it("should scrape description", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ description: "My desc" }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults).toEqual([expect.objectContaining({
+                description: "My desc"
+            })]);
+        });
+
+        it("should scrape url", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ path: "/myad" }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults).toEqual([expect.objectContaining({
+                url: "https://www.kijiji.ca/myad"
+            })]);
+        });
+
+        it("should exclude featured ads", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) + createResultHTML({ isFeatured: true }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults.length).toBe(1);
+        });
+
+        it("should exclude third-party ads", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) + createResultHTML({ isThirdParty: true }) });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults.length).toBe(1);
+        });
+
+        it.each`
+            isLastPage
+            ${true}
+            ${false}
+        `("should detect last page (isLastPage=$isLastPage)", async ({ isLastPage }) => {
+            let mockResponse = createResultHTML({});
+            if (isLastPage) {
+                mockResponse += '"isLastPage":true';
+            }
+            fetchSpy.mockResolvedValueOnce({ text: () => mockResponse });
+
+            const result = await search();
+            validateRequestHeaders();
+            expect(result.pageResults.length).toBe(1);
+            expect(result.isLastPage).toBe(isLastPage);
+        });
+
+        it("should handle empty response", async () => {
+            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+
+            const { pageResults } = await search();
+            validateRequestHeaders();
+            expect(pageResults.length).toBe(0);
+        });
+    });
+});

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -3,7 +3,7 @@
 /**
  * Ad categories and their corresponding Kijiji categoryId values
  */
-export default {
+export const categories = {
     id: 0,
     KIJIJI_VILLAGE: { id: 36611001 },
     BUY_AND_SELL: {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,3 +20,8 @@ export const API_REQUEST_HEADERS = {
 export const POSSIBLE_BAD_MARKUP =
     "It is possible that Kijiji changed their markup. " +
     `If you believe this to be the case, please open an issue at: ${BUGS_URL}`;
+
+export const BANNED =
+    "Kijiji denied access. You are likely temporarily blocked. This can happen if " +
+    "you scrape too aggressively. Try scraping again later, and more slowly. If " +
+    `this happens even when scraping reasonably, please open an issue at: ${BUGS_URL}`;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,22 @@
+const BUGS_URL = "https://github.com/mwpenny/kijiji-scraper/issues";
+
+// I'm not sure how much this helps with getting banned, but it seems to
+export const HTML_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0"
+};
+
+// Some of these headers are redundant, but I want them in the same order the app sends
+export const API_REQUEST_HEADERS = {
+    "User-Agent": "com.ebay.kijiji.ca 6.5.0 (samsung SM-G930U; Android 8.0.0; en_US)",
+    "Accept-Language": "en-CA",
+    Accept: "application/xml",
+    Connection: "close",
+    Pragma: "no-cache",
+    Authorization: "Basic Y2FfYW5kcm9pZF9hcHA6YXBwQ2xAc3NpRmllZHMh",
+    Host: "mingle.kijiji.ca",
+    "Accept-Encoding": "gzip, deflate"
+};
+
+export const POSSIBLE_BAD_MARKUP =
+    "It is possible that Kijiji changed their markup. " +
+    `If you believe this to be the case, please open an issue at: ${BUGS_URL}`;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,0 +1,70 @@
+// helpers.ts
+/* Common functionality */
+
+import cheerio from "cheerio";
+
+const IMG_REGEX = /\/\$_\d+\.(?:JPG|PNG)$/;
+
+/**
+ * Kijiji scraping method
+ */
+export enum ScraperType {
+    /**
+     * Scrape using the Kijiji mobile API
+     */
+    API = "api",
+
+    /**
+     * Scrape by parsing the HTML of Kijiji.ca
+     */
+    HTML = "html"
+};
+
+/**
+ * Options to pass to the scraper
+ */
+export type ScraperOptions = {
+    /**
+     * Which scraping method to use. Either "api" (default) or "html"
+     */
+    scraperType?: ScraperType;
+};
+
+export function isNumber(value: string) {
+    value = value.trim();
+    return value.length > 0 && !Number.isNaN(Number(value)) && Number.isFinite(Number(value));
+};
+
+export function getLargeImageURL(url: string): string {
+    // Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
+    // number between 0 and 140 indicating the desired image size and
+    // quality. "57" is up to 1024x1024, the largest I've found.
+    return url.replace(IMG_REGEX, "/$_57.JPG");
+}
+
+export function cleanAdDescription(text: string): string {
+    // Some descriptions contain HTML. Remove it so it is only text
+    const $ = cheerio.load(text);
+    $("label").remove();  // Remove kit-ref-id label
+    return $.root().text().trim();
+}
+
+export function getScraperOptions(options: ScraperOptions): Required<ScraperOptions> {
+    // Copy options so we don't modify what was passed
+    const scraperOptions = { ...options };
+
+    // Option defaults
+    if (scraperOptions.scraperType === undefined) {
+        scraperOptions.scraperType = ScraperType.API;
+    }
+
+    const validScraperTypes = Object.values(ScraperType);
+    if (validScraperTypes.find(k => k === scraperOptions.scraperType) === undefined) {
+        throw new Error(
+            "Invalid value for scraper option 'scraperType'. Valid values are: " +
+            validScraperTypes.join(", ")
+        );
+    }
+
+    return scraperOptions as Required<ScraperOptions>;
+}

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -30,7 +30,13 @@ export type ScraperOptions = {
     scraperType?: ScraperType;
 };
 
-export function isNumber(value: string) {
+export function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export function isNumber(value: string): boolean {
     value = value.trim();
     return value.length > 0 && !Number.isNaN(Number(value)) && Number.isFinite(Number(value));
 };

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -3,7 +3,7 @@
 /**
  * Geographical locations and their corresponding Kijiji locationId values
  */
-export default {
+export const locations = {
     id: 0,
     ALBERTA: {
         id: 9003,

--- a/lib/scraper.ts
+++ b/lib/scraper.ts
@@ -1,10 +1,10 @@
-// ad-scraper.ts
-/* Scrapes a Kijiji ad and returns its information */
+// scraper.ts
+/* Generic interface to scrape Kijiji ad information */
 
-import fetch from "node-fetch";
-import cheerio from "cheerio";
-
-const IMG_REGEX = /\/\$_\d+\.(?:JPG|PNG)$/;
+import { scrapeAPI } from "./backends/api-scraper";
+import { scrapeHTML } from "./backends/html-scraper";
+import { POSSIBLE_BAD_MARKUP } from "./constants";
+import { getScraperOptions, ScraperOptions, ScraperType } from "./helpers";
 
 /**
  * Information about an ad from Kijiji
@@ -44,97 +44,24 @@ export class AdInfo {
      * The ad's URL
      */
     url: string = "";
-}
-
-function cleanDesc(text: string): string {
-    // Some descriptions contain HTML. Remove it so it is only text
-    let $ = cheerio.load(text);
-    $("label").remove();  // Remove kit-ref-id label
-    return $.root().text().trim();
-}
-
-function castVal(val: string): boolean | number | Date | string {
-    // Kijiji only returns strings. Convert to appropriate types
-    if (val === "true") {
-        return true;
-    } else if (val === "false") {
-        return false;
-    } else if (!Number.isNaN(Number(val)) && Number.isFinite(Number(val))) {
-        return Number(val);
-    } else if (!isNaN(Date.parse(val))) {
-        return new Date(val);
-    } else {
-        return val;
-    }
-}
-
-/* Parses the HTML of a Kijiji ad for its important information */
-function parseHTML(html: string): AdInfo | null {
-    const info = new AdInfo();
-
-    // Kijiji is nice and gives us an object containing ad info
-    const $ = cheerio.load(html);
-    let adData: any = {};
-    let json = $("#FesLoader > script").text().replace("window.__data=", "");
-    json = json.substring(0, json.length - 1);  // Remove trailing semicolon
-
-    if (json.length === 0 || Object.keys(adData = JSON.parse(json)).length === 0 ||
-        !adData.hasOwnProperty("config") || !adData.config.hasOwnProperty("adInfo") ||
-        !adData.config.hasOwnProperty("VIP")) {
-        return null;
-    }
-
-    adData = adData.config;
-    info.title = adData.adInfo.title;
-    info.description = cleanDesc(adData.VIP.description || "");
-    info.date = new Date(adData.VIP.sortingDate);
-
-    /* Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
-       number between 0 and 140 indicating the desired image size and
-       quality. "57" is up to 1024x1024, the largest I've found. */
-    info.image = (adData.adInfo.sharingImageUrl || "").replace(IMG_REGEX, "/$_57.JPG");
-
-    (adData.VIP.media || []).forEach((m: any) => {
-        if (m.type === "image" && m.href && typeof m.href === "string") {
-            info.images.push(m.href.replace(IMG_REGEX, "/$_57.JPG"));
-        }
-    });
-    (adData.VIP.adAttributes || []).forEach((a: any) => {
-        if (typeof a.machineKey === "string" && typeof a.machineValue === "string") {
-            info.attributes[a.machineKey] = castVal(a.machineValue);
-        }
-    });
-
-    // Add other attributes of interest
-    // TODO: This VIP object contains much more. Worth a closer look.
-    if (adData.VIP.price && typeof adData.VIP.price.amount === "number") {
-        info.attributes["price"] = adData.VIP.price.amount/100.0;
-    }
-    if (adData.VIP.adLocation) {
-        info.attributes["location"] = adData.VIP.adLocation;
-    }
-    if (adData.VIP.adType) {
-        info.attributes["type"] = adData.VIP.adType;
-    }
-    if (adData.VIP.visitCounter) {
-        info.attributes["visits"] = adData.VIP.visitCounter;
-    }
-    return info;
-}
+};
 
 /* Scrapes the passed Kijiji ad URL */
-export default function scrape(url: string): Promise<AdInfo> {
+type Scraper = (adUrl: string) => Promise<AdInfo | null>;
+export async function scrape(url: string, options: ScraperOptions = {}): Promise<AdInfo> {
     if (!url) {
         throw new Error("URL must be specified");
     }
 
-    return fetch(url)
-            .then(res => res.text())
-            .then(body => {
-                const adInfo = parseHTML(body);
-                if (!adInfo)
-                    throw new Error(`Ad not found or invalid Kijiji HTML at ${url}`);
-                adInfo.url = url;
-                return adInfo
-            });
+    const scraperOptions = getScraperOptions(options);
+    const scraper: Scraper = scraperOptions.scraperType === ScraperType.HTML ? scrapeHTML : scrapeAPI;
+
+    const adInfo = await scraper(url);
+    if (!adInfo) {
+        throw new Error(
+            `Ad not found or invalid response received from Kijiji for ad at ${url}. ${POSSIBLE_BAD_MARKUP}`
+        );
+    }
+    adInfo.url = url;
+    return adInfo;
 }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,19 +1,11 @@
 // search.ts
 /* Searches Kijiji for recent ads matching given criteria */
 
-import cheerio from "cheerio";
-import qs from "querystring";
-import fetch, { Response as FetchResponse } from "node-fetch";
-
-import KijijiAd from "./ad";
-import { AdInfo } from "./scraper";
-
-const packageJson = require("../../package.json");
-
-const KIJIJI_BASE_URL = "https://www.kijiji.ca";
-const KIJIJI_SEARCH_URL = KIJIJI_BASE_URL + "/b-search.html";
-const IMG_REGEX = /\/s\-l\d+\.jpg$/;
-const LOCATION_REGEX = /(.+)(\/.*)$/;
+import { Ad } from "./ad";
+import { APISearcher } from "./backends/api-searcher";
+import { HTMLSearcher } from "./backends/html-searcher";
+import { POSSIBLE_BAD_MARKUP } from "./constants";
+import { getScraperOptions, ScraperOptions, ScraperType } from "./helpers";
 
 // Helper for location and category IDs
 type KijijiIdTreeNode = { id: number };
@@ -33,6 +25,21 @@ export type SearchParameters = {
     categoryId?: number | KijijiIdTreeNode;
 
     /**
+     * The minimum desired price of the results
+     */
+    minPrice?: number;
+
+    /**
+     * The maximum desired price of the results
+     */
+    maxPrice?: number;
+
+    /**
+     * Type of ad to return. Leave undefined for both
+     */
+    adType?: "OFFER" | "WANTED";
+
+    /**
      * Other parameters, specific to the category. Use browser developer
      * tools when performing a specific search to find more parameters.
      * After submitting your search on Kijiji or updating the filter being
@@ -40,6 +47,12 @@ export type SearchParameters = {
      * Any parameter used in the query string for that request is able to be
      * specified in here.
      */
+    [paramName: string]: any;
+};
+
+export type ResolvedSearchParameters = {
+    locationId: number;
+    categoryId: number;
     [paramName: string]: any;
 };
 
@@ -59,8 +72,8 @@ export type SearchOptions = {
 
     /**
      * Minimum number of ads to fetch (if available). Note that Kijiji results
-     * are returned in pages of up to `40` ads, so if you set this to something
-     * like `49`, up to `80` results may be retrieved.
+     * are returned in pages of up to `20` ads, so if you set this to something
+     * like `29`, up to `40` results may be retrieved.
      */
     minResults?: number;
 
@@ -73,143 +86,55 @@ export type SearchOptions = {
     maxResults?: number;
 };
 
-/* Converts a date from a Kijiji ad result into a date object
-   (e.g., "< x hours ago", "yesterday", "dd/mm/yyyy") */
-function dateFromRelativeDateString(dateString: string): Date {
-    if (dateString) {
-        dateString = dateString.toLowerCase().replace(/\//g, " ");
+/**
+ * The search results for one page
+ */
+export type PageResults = {
+    /**
+     * Ads from the result page
+     */
+    pageResults: Ad[];
 
-        const split = dateString.split(" ");
-        const d = new Date();
+    /**
+     * Whether or not this page is the last page of results
+     */
+    isLastPage: boolean;
+};
 
-        if (split.length === 3) {
-            // dd/mm/yyyy format
-            d.setHours(0, 0, 0, 0);
-            d.setDate(parseInt(split[0]));
-            d.setMonth(parseInt(split[1]) - 1);
-            d.setFullYear(parseInt(split[2]));
-            return d;
-        } else if (split.length === 4) {
-            // "< x hours/minutes ago" format
-            const num = parseInt(split[1]);
-            const timeUnit = split[2];
-
-            if (timeUnit === "minutes") {
-                d.setMinutes(d.getMinutes() - num);
-                d.setSeconds(0, 0);
-            } else if (timeUnit === "hours") {
-                d.setHours(d.getHours() - num, 0, 0, 0);
-            }
-            return d;
-        } else if (dateString == "yesterday") {
-            d.setDate(d.getDate() - 1);
-            d.setHours(0, 0, 0, 0);
-            return d;
-        }
-    }
-    return new Date(NaN);
-}
-
-/* Extracts ad information from the HTML of a Kijiji ad results page */
-function parseResultsHTML(html: string): KijijiAd[] {
-    const adResults: KijijiAd[] = [];
-    const $ = cheerio.load(html);
-
-    // Get info for each ad
-    const allAdElements = $(".regular-ad");
-    const filteredAdElements = allAdElements.not(".third-party");
-
-    filteredAdElements.each((_i, item) => {
-        const url = KIJIJI_BASE_URL + $(item).find("a.title").attr("href");
-        const info: Partial<AdInfo> = {
-            title: $(item).find("a.title").text().trim(),
-
-            image: (
-                // `data-src` contains the URL of the image to lazy load
-                //
-                // `src` starts off with a placeholder image and will
-                // remain if the ad has no image
-                $(item).find(".image img").data("src") || $(item).find(".image img").attr("src") || ""
-            ).replace(IMG_REGEX, "/s-l2000.jpg"),
-
-            date: dateFromRelativeDateString(
-                // For some reason, some categories (like anything under
-                // SERVICES) use different markup than usual
-                //
-                // The string split is needed to handle:
-                //
-                // <td class="posted">
-                //    Some date
-                //    <br>
-                //    Some location
-                // </td>
-                //
-                // AKA "Some date\nSome location"
-                ($(item).find(".date-posted").text() || $(item).find(".posted").text()).trim().split("\n")[0]
-            ),
-
-            // Pick a format, Kijiji
-            description: ($(item).find(".description > p").text() || $(item).find(".description").text()).trim()
-        };
-        adResults.push(new KijijiAd(url, info));
-    });
-    return adResults;
-}
-
-/* Retrieves the URL of the first page of search results */
-async function getFirstResultPageURL(params: SearchParameters): Promise<string> {
-    const res: FetchResponse = await fetch(`${KIJIJI_SEARCH_URL}?${qs.stringify(params)}`);
-
-    // Kijiji will redirect to the rendered results
-    // Grab the destination path so that it can be modified for pagination
-    if (res.status !== 200 || !res.url) {
-        // TODO: detect ban and show a different message
-        const bugsUrl = packageJson.bugs.url;
-        throw new Error(
-            "Kijiji failed to return search results. " +
-            "It is possible that Kijiji changed their results markup. " +
-            `If you believe this to be the case, please open a bug at: ${bugsUrl}`
-        );
-    }
-    return res.url;
-}
-
-/* Retrieves one page of Kijiji search results */
-type PageResults = { pageResults: KijijiAd[], isLastPage: boolean };
-async function getPageResults(pageNum: number, firstResultPageURL: string): Promise<PageResults> {
-    // Specify page number. It must be the last path component of the URL
-    const url = firstResultPageURL.replace(LOCATION_REGEX, `$1/page-${pageNum}$2`);
-
-    // Search Kijiji
-    const body = await fetch(url).then(res => res.text());
-    try {
-        return {
-            pageResults: parseResultsHTML(body),
-            isLastPage: body.indexOf('"isLastPage":true') !== -1
-        };
-    } catch (err) {
-        // Invalid results page
-        console.warn(`WARNING: Failed to parse search result: ${err}`);
-        throw new Error(`Invalid Kijiji HTML on search results page (${url})`);
-    }
-}
+/**
+ * Generic interface for a Kijiji searcher
+ */
+export interface Searcher {
+    /**
+     * Retrieve one page of search results
+     * @param params Search parameters
+     * @param pageNum Page number to return results for
+     * @returns The results for the specified page
+     */
+    getPageResults(params: ResolvedSearchParameters, pageNum: number): Promise<PageResults>;
+};
 
 /* Retrieves at least minResults search results from Kijiji using the passed parameters */
-async function getSearchResults(params: SearchParameters, minResults: number): Promise<KijijiAd[]> {
+async function getSearchResults(searcher: Searcher, params: ResolvedSearchParameters, minResults: number): Promise<Ad[]> {
     /* When searching with formSubmit = true, Kijiji will redirect us to a URL
        that the UI uses to encode search parameters. This URL can be modified to
        specify the page number (the only reliable way I have found to do so) */
-    const firstResultPageURL = await getFirstResultPageURL(params);
-    const results: KijijiAd[] = [];
+    const results: Ad[] = [];
     let pageNum = 1;
 
-    while (results.length < minResults) {
-        const { pageResults, isLastPage } = await getPageResults(pageNum++, firstResultPageURL);
-        results.push(...pageResults);
+    try {
+        while (results.length < minResults) {
+            const { pageResults, isLastPage } = await searcher.getPageResults(params, pageNum++);
+            results.push(...pageResults);
 
-        if (pageResults.length === 0 || isLastPage) {
-            break;
+            if (pageResults.length === 0 || isLastPage) {
+                break;
+            }
         }
+    } catch (err) {
+        throw new Error(
+            `Error parsing Kijiji search results: ${err.message}. ${POSSIBLE_BAD_MARKUP}`
+        );
     }
     return results;
 }
@@ -222,7 +147,7 @@ function ensureIntProp(obj: any, propName: string): void {
 }
 
 /* Parses search parameters, adds default values if required, and then performs validation */
-function getSearchParams(params: any): Required<SearchParameters> {
+function getSearchParams(params: SearchParameters): ResolvedSearchParameters {
     const getId = (id: any): number => {
         // If id is an id object, return the contained id
         let ret = id;
@@ -256,9 +181,10 @@ function getSearchParams(params: any): Required<SearchParameters> {
 
     ensureIntProp(paramsForSearch, "locationId");
     ensureIntProp(paramsForSearch, "categoryId");
-    return paramsForSearch;
+    return paramsForSearch as ResolvedSearchParameters;
 }
 
+/* Parses search options, adds default values if required, and then performs validation */
 function getSearchOptions(options: SearchOptions): Required<SearchOptions> {
     // Copy options so we don't modify what was passed
     const optionsForSearch = { ...options };
@@ -268,7 +194,7 @@ function getSearchOptions(options: SearchOptions): Required<SearchOptions> {
         optionsForSearch.scrapeResultDetails = true;
     }
     if (optionsForSearch.minResults === undefined) {
-        optionsForSearch.minResults = 40;
+        optionsForSearch.minResults = 20;
     }
     if (optionsForSearch.maxResults === undefined) {
         optionsForSearch.maxResults = -1;
@@ -283,25 +209,35 @@ function getSearchOptions(options: SearchOptions): Required<SearchOptions> {
  * Searches Kijiji for ads matching the given criteria
  *
  * @param params Kijiji ad search parameters
- * @param options Scraper options
+ * @param options Search and scraper options
  * @param callback Called after the search results have been scraped. If an error
  *                 occurs during scraping, `err` will not be null. If everything
  *                 is successful, `results` will contain an array of `Ad` objects.
  * @returns `Promise` which resolves to an array of search result `Ad` objects
  */
-export default function search(params: SearchParameters, options: SearchOptions = {}, callback?: (err: Error | null, ads: KijijiAd[]) => void): Promise<KijijiAd[]> {
-    const promise: Promise<KijijiAd[]> = new Promise((resolve, reject) => {
+export function search(params: SearchParameters, options: SearchOptions & ScraperOptions = {}, callback?: (err: Error | null, ads: Ad[]) => void): Promise<Ad[]> {
+    const promise: Promise<Ad[]> = new Promise((resolve, reject) => {
         // Configure search
         const paramsForSearch = getSearchParams(params);
         const optionsForSearch = getSearchOptions(options);
+        const scraperOptions = getScraperOptions(options);
+
+        const searcher: Searcher = scraperOptions.scraperType === ScraperType.HTML
+            ? new HTMLSearcher()
+            : new APISearcher();
 
         // Perform search
-        getSearchResults(paramsForSearch, optionsForSearch.minResults).then(results => {
+        getSearchResults(searcher, paramsForSearch, optionsForSearch.minResults).then(results => {
             if (optionsForSearch.maxResults >= 0) {
                 results = results.slice(0, optionsForSearch.maxResults);
             }
             if (optionsForSearch.scrapeResultDetails) {
-                return Promise.all(results.map(ad => ad.scrape())).then(() => results);
+                // TODO: rate limiting
+                return Promise.all(results.map(ad => {
+                    if (!ad.isScraped()) {
+                        ad.scrape();
+                    }
+                })).then(() => results);
             }
             return results;
         }).then(resolve, reject);

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -4,7 +4,6 @@
 import { Ad } from "./ad";
 import { APISearcher } from "./backends/api-searcher";
 import { HTMLSearcher } from "./backends/html-searcher";
-import { POSSIBLE_BAD_MARKUP } from "./constants";
 import { getScraperOptions, ScraperOptions, ScraperType } from "./helpers";
 
 // Helper for location and category IDs
@@ -132,9 +131,7 @@ async function getSearchResults(searcher: Searcher, params: ResolvedSearchParame
             }
         }
     } catch (err) {
-        throw new Error(
-            `Error parsing Kijiji search results: ${err.message}. ${POSSIBLE_BAD_MARKUP}`
-        );
+        throw new Error(`Error parsing Kijiji search results: ${err.message}`);
     }
     return results;
 }

--- a/lib/test/helpers.spec.ts
+++ b/lib/test/helpers.spec.ts
@@ -1,6 +1,29 @@
-import { isNumber, getLargeImageURL, cleanAdDescription, getScraperOptions, ScraperOptions, ScraperType } from "../helpers";
+import { isNumber, getLargeImageURL, cleanAdDescription, getScraperOptions, ScraperOptions, ScraperType, sleep } from "../helpers";
 
 describe("Helpers", () => {
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("sleep should wait the specified time", async () => {
+        let callback: Function | undefined = undefined;
+        setTimeoutSpy.mockImplementationOnce(
+            (handler: TimerHandler, _timeout?: number, ..._args: any[]) => {
+                callback = handler as Function;
+                return 0;
+            }
+        );
+
+        const promise = sleep(1234).then(() => "done");
+        expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), 1234);
+        expect(callback).toBeDefined();
+
+        callback!();
+        expect(await promise).toBe("done");
+    });
+
     it.each`
         input         | expectedResult
         ${"123"}      | ${true}

--- a/lib/test/helpers.spec.ts
+++ b/lib/test/helpers.spec.ts
@@ -1,0 +1,67 @@
+import { isNumber, getLargeImageURL, cleanAdDescription, getScraperOptions, ScraperOptions, ScraperType } from "../helpers";
+
+describe("Helpers", () => {
+    it.each`
+        input         | expectedResult
+        ${"123"}      | ${true}
+        ${" 123 "}    | ${true}
+        ${"1.23"}     | ${true}
+        ${"-123"}     | ${true}
+        ${"-1.23"}    | ${true}
+        ${"-123"}     | ${true}
+        ${""}         | ${false}
+        ${" "}        | ${false}
+        ${"abc123"}   | ${false}
+        ${"1.2.3"}    | ${false}
+        ${"Infinity"} | ${false}
+        ${"abc"}      | ${false}
+    `("isNumber should detect numbers (input='$input')", ({ input, expectedResult }) => {
+        expect(isNumber(input)).toBe(expectedResult);
+    });
+
+    it.each`
+        test             | url                                     | expectedURL
+        ${"regular URL"} | ${"http://example.com"}                 | ${"http://example.com"}
+        ${"upsize JPG"}  | ${"http://example.com/images/$_12.JPG"} | ${"http://example.com/images/$_57.JPG"}
+        ${"upsize PNG"}  | ${"http://example.com/images/$_34.PNG"} | ${"http://example.com/images/$_57.JPG"}
+    `("getLargeImageURL should upsize image URLs ($test)", ({ url, expectedURL }) => {
+        expect(getLargeImageURL(url)).toBe(expectedURL);
+    });
+
+    it.each`
+        test                | description
+        ${"well formatted"} | ${"My ad description"}
+        ${"with label"}     | ${"My ad <label>blah</label>description"}
+        ${"untrimmed"}      | ${"  \n\n  My ad description      \r\n"}
+    `("cleanAdDescription should clean ad descriptions ($test)", ({ description }) => {
+        expect(cleanAdDescription(description)).toBe("My ad description");
+    });
+
+    describe("get scraper options", () => {
+        describe("scraper type", () => {
+            it("should throw error for invalid scraper type", () => {
+                const scraperOptions = { scraperType: "invalid" } as any as ScraperOptions;
+
+                try {
+                    getScraperOptions(scraperOptions);
+                    fail("Expected error for bad scraper options");
+                } catch (err) {
+                    expect(err.message).toBe("Invalid value for scraper option 'scraperType'. Valid values are: api, html");
+                }
+            });
+
+            it.each`
+                scraperType
+                ${ScraperType.API}
+                ${ScraperType.HTML}
+            `("should allow valid scraper to be specified (scraperType=$scraperType)", async ({ scraperType }) => {
+                const scraperOptions = { scraperType };
+                expect(getScraperOptions(scraperOptions)).toEqual(scraperOptions);
+            });
+
+            it("should default to API scraper", () => {
+                expect(getScraperOptions({})).toEqual({ scraperType: ScraperType.API });
+            });
+        });
+    });
+});

--- a/lib/test/scraper.spec.ts
+++ b/lib/test/scraper.spec.ts
@@ -1,32 +1,34 @@
-jest.mock("node-fetch");
+jest.mock("../backends/api-scraper");
+jest.mock("../backends/html-scraper");
 
-import fetch from "node-fetch";
-import scraper from "../scraper";
+import { AdInfo, scrape } from "../scraper";
+import * as helpers from "../helpers";
+import * as apiScraper from "../backends/api-scraper";
+import * as htmlScraper from "../backends/html-scraper";
 
-const fetchSpy = fetch as any as jest.Mock;
+const scrapeAPISpy = jest.spyOn(apiScraper, "scrapeAPI");
+const scrapeHTMLSpy = jest.spyOn(htmlScraper, "scrapeHTML");
 
-describe("Ad HTML scraper", () => {
+describe.each`
+    scraperType
+    ${helpers.ScraperType.API}
+    ${helpers.ScraperType.HTML}
+`("Ad scraper (scraperType=$scraperType)", ({ scraperType }) => {
+    const activeScraper = scraperType === helpers.ScraperType.API ? scrapeAPISpy : scrapeHTMLSpy;
+    const allScrapers = [
+        scrapeAPISpy,
+        scrapeHTMLSpy
+    ];
+
+    const getScraperOptionsSpy = jest.spyOn(helpers, "getScraperOptions");
+
+    beforeEach(() => {
+        getScraperOptionsSpy.mockReturnValue({ scraperType });
+    });
+
     afterEach(() => {
         jest.resetAllMocks();
     });
-
-    const mockResponse = (body: string) => {
-        fetchSpy.mockResolvedValue({
-            text: () => body
-        });
-    };
-
-    const createAdHTML = (info: any) => {
-        return `
-            <html>
-                <body>
-                    <div id="FesLoader">
-                        <script type="text/javascript">window.__data=${JSON.stringify(info)};</script>
-                    </div>
-                </body>
-            </html>
-        `;
-    };
 
     it.each`
         url
@@ -35,257 +37,60 @@ describe("Ad HTML scraper", () => {
         ${""}
     `("should throw error if URL is not passed (url=$url)", async ({ url }) => {
         try {
-            await scraper(url);
+            await scrape(url);
             fail("Expected error for bad URL");
         } catch (err) {
             expect(err.message).toBe("URL must be specified");
-            expect(fetchSpy).not.toBeCalled();
+            allScrapers.forEach(s => expect(s).not.toBeCalled());
         }
     });
 
-    it.each`
-        test                         | html
-        ${"Bad markup"}              | ${"Bad markup"}
-        ${"Missing FesLoader"}       | ${"<html></html>"}
-        ${"Empty FesLoader"}         | ${createAdHTML({})}
-        ${"Missing config property"} | ${createAdHTML({ abc: 123 })}
-        ${"Missing adInfo property"} | ${createAdHTML({ config: {} })}
-        ${"Missing VIP property"}    | ${createAdHTML({ config: { adInfo: {} } })}
-    `("should throw error for invalid HTML ($test)", async ({ html }) => {
-        mockResponse(html);
+    it("should throw error if no ad info is returned", async () => {
+        const url = "http://example.com";
 
         try {
-            await scraper("http://example.com");
-            fail("Expected error for bad HTML");
+            await scrape(url);
+            fail("Expected error for no ad info");
         } catch (err) {
-            expect(err.message).toBe("Ad not found or invalid Kijiji HTML at http://example.com");
+            expect(err.message).toBe(
+                "Ad not found or invalid response received from Kijiji for " +
+                "ad at http://example.com. It is possible that Kijiji changed " +
+                "their markup. If you believe this to be the case, please open " +
+                "an issue at: https://github.com/mwpenny/kijiji-scraper/issues"
+            );
+            expect(activeScraper).toBeCalledWith(url)
+            allScrapers.forEach(s => {
+                if (s !== activeScraper) {
+                    expect(s).not.toBeCalled();
+                }
+            });
         }
     });
 
-    describe("valid markup", () => {
-        it("should scrape title", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {
-                        title: "My ad title"
-                    },
-                    VIP: {}
-                }
-            }));
+    it("should not scrape if retrieving options throws error", async () => {
+        getScraperOptionsSpy.mockImplementation(() => { throw new Error("Bad options"); });
 
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.title).toBe("My ad title");;
+        try {
+            await scrape("http://example.com", {});
+            fail("Expected error for bad scraper options");
+        } catch (err) {
+            expect(err.message).toBe("Bad options");
+            allScrapers.forEach(s => expect(s).not.toBeCalled());
+        }
+    });
+
+    it("should set ad URL", async () => {
+        activeScraper.mockResolvedValue(new AdInfo());
+
+        const url = "http://example.com";
+        const adInfo = await scrape(url);
+
+        expect(activeScraper).toBeCalledWith(url);
+        allScrapers.forEach(s => {
+            if (s !== activeScraper) {
+                expect(s).not.toBeCalled();
+            }
         });
-
-        it.each`
-            test                | description
-            ${"well formatted"} | ${"My ad description"}
-            ${"with label"}     | ${"My ad <label>blah</label>description"}
-            ${"untrimmed"}      | ${"  \n\n  My ad description      \r\n"}
-        `("should scrape description ($test)", async ({ description }) => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        description
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.description).toBe("My ad description");
-        });
-
-        it("should scrape date", async () => {
-            const date = new Date();
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        sortingDate: date
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.date).toEqual(date);
-        });
-
-        it.each`
-            test             | url                                     | expectedUrl
-            ${"null URL"}    | ${null}                                 | ${""}
-            ${"regular URL"} | ${"http://example.com"}                 | ${"http://example.com"}
-            ${"upsize JPG"}  | ${"http://example.com/images/$_12.JPG"} | ${"http://example.com/images/$_57.JPG"}
-            ${"upsize PNG"}  | ${"http://example.com/images/$_34.PNG"} | ${"http://example.com/images/$_57.JPG"}
-        `("should scrape image ($test)", async ({ url, expectedUrl }) => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {
-                        sharingImageUrl: url
-                    },
-                    VIP: {}
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.image).toBe(expectedUrl);
-        });
-
-        it("should scrape ad images", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        media: [
-                            // Invalid
-                            { type: "not-an-image", href: "http://example.org" },
-                            { type: "image", href: "" },
-                            { type: "image", href: 123 },
-                            { type: "image" },
-
-                            // Valid
-                            { type: "image", href: "http://example.com/image" },
-                            { type: "image", href: "http://example.com/images/$_12.JPG" },
-                            { type: "image", href: "http://example.com/images/$_34.PNG" },
-                        ]
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.images).toEqual([
-                "http://example.com/image",
-                "http://example.com/images/$_57.JPG",
-                "http://example.com/images/$_57.JPG",
-            ]);
-        });
-
-        it.each`
-            test               | value                         | expectedValue
-            ${"true boolean"}  | ${"true"}                     | ${true}
-            ${"false boolean"} | ${"false"}                    | ${false}
-            ${"integer"}       | ${"123"}                      | ${123}
-            ${"float"}         | ${"1.21"}                     | ${1.21}
-            ${"date"}          | ${"2020-09-06T20:52:47.474Z"} | ${new Date(1599425567474)}
-            ${"string"}        | ${"hello"}  | ${"hello"}
-        `("should scrape ad attribute ($test)", async ({ value, expectedValue }) => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        adAttributes: [
-                            // Invalid
-                            {},
-                            { machineKey: 123 },
-                            { machineValue: 456 },
-                            { machineKey: 123, machineValue: 456 },
-                            { machineKey: "invalid", machineValue: 456 },
-                            { machineKey: 123, machineValue: "invalid" },
-
-                            // Valid
-                            { machineKey: "myAttr", machineValue: value }
-                        ]
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.attributes).toEqual({
-                myAttr: expectedValue
-            });
-        });
-
-        it("should scrape images", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        media: [
-                            { type: "image", href: "http://example.com/image1" },
-                            { type: "image", href: "http://example.com/image2" }
-                        ]
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.images).toEqual([
-                "http://example.com/image1",
-                "http://example.com/image2"
-            ]);
-        });
-
-        it.each`
-            test                    | value                | expected
-            ${"no amount"}          | ${null}              | ${undefined}
-            ${"non-numeric amount"} | ${{ amount: "abc" }} | ${undefined}
-            ${"with amount"}        | ${{ amount: 123 }}   | ${1.23}
-        `("should scrape price ($test)", async ({ value, expected }) => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        price: value
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.attributes.price).toBe(expected);
-        });
-
-        it("should scrape location", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        adLocation: "Some location"
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.attributes.location).toBe("Some location");
-        });
-
-        it("should scrape type", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        adType: "Some type"
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.attributes.type).toBe("Some type");
-        });
-
-        it("should scrape visits", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {
-                        visitCounter: 12345
-                    }
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.attributes.visits).toBe(12345);
-        });
-
-        it("should set URL", async () => {
-            mockResponse(createAdHTML({
-                config: {
-                    adInfo: {},
-                    VIP: {}
-                }
-            }));
-
-            const adInfo = await scraper("http://example.com");
-            expect(adInfo.url).toBe("http://example.com");
-        });
+        expect(adInfo.url).toBe(url);
     });
 });

--- a/lib/test/search.spec.ts
+++ b/lib/test/search.spec.ts
@@ -56,10 +56,7 @@ describe.each`
             fail("Expected error while searching");
         } catch (err) {
             expect(err.message).toBe(
-                "Error parsing Kijiji search results: Error searching. " +
-                "It is possible that Kijiji changed their markup. " +
-                "If you believe this to be the case, please open an issue at: " +
-                "https://github.com/mwpenny/kijiji-scraper/issues"
+                "Error parsing Kijiji search results: Error searching"
             );
         }
     });

--- a/lib/test/search.spec.ts
+++ b/lib/test/search.spec.ts
@@ -1,115 +1,36 @@
-jest.mock("node-fetch");
-
-import cheerio from "cheerio";
-import fetch from "node-fetch";
-import qs from "querystring";
-import search, { SearchParameters } from "../search";
+import { Ad } from "../ad";
+import { search, SearchParameters } from "../search";
+import { APISearcher } from "../backends/api-searcher";
+import { HTMLSearcher } from "../backends/html-searcher";
+import * as helpers from "../helpers";
 import * as scraper from "../scraper";
 
-const fetchSpy = fetch as any as jest.Mock;
-const scraperSpy = jest.spyOn(scraper, "default");
-
-type ResultInfo = {
-    isFeatured: boolean;
-    isThirdParty: boolean;
-    title: string;
-    path: string;
-    description: string;
-    imageAttributes: string;
-    datePosted: string;
-};
-
-const defaultResultInfo: ResultInfo = {
-    isFeatured: false,
-    isThirdParty: false,
-    title: "",
-    path: "",
-    description: "",
-    imageAttributes: "",
-    datePosted: ""
-};
-
-// Result pages in most categories use this markup
-const createStandardResultHTML = (info: Partial<ResultInfo>): string => {
-    info = { ...defaultResultInfo, ...info };
-
-    return `
-        <div class="search-item
-            ${info.isFeatured ? "top-feature" : "regular-ad"}
-            ${info.isThirdParty ? "third-party" : ""}">
-            <div class="clearfix">
-                <div class="left-col">
-                    <div class="image">
-                        <picture><img ${info.imageAttributes}></picture>
-                    </div>
-
-                    <div class="info">
-                        <div class="info-container">
-                            <div class="title">
-                                <a class="title" href="${info.path}">${info.title}</a>
-                            </div>
-
-                            <div class="location">
-                                <span class="">Some location</span>
-                                <span class="date-posted">${info.datePosted}</span>
-                            </div>
-
-                            <div class="description">${info.description}</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-};
-
-// For some reason, some categories (like anything under
-// SERVICES) use different markup classes than usual
-const createServiceResultHTML = (info: Partial<ResultInfo>): string => {
-    info = { ...defaultResultInfo, ...info };
-
-    return `
-        <table class="
-            ${info.isFeatured ? "top-feature" : "regular-ad"}
-            ${info.isThirdParty ? "third-party" : ""}">
-            <tbody>
-                <tr>
-                    <td class="description">
-                        <a class="title" href="${info.path}">${info.title}</a>
-                        <p>${info.description}</p>
-                    </td>
-
-                    <td class="image">
-                        <div class="multiple-images">
-                            <picture><img ${info.imageAttributes}></picture>
-                        </div>
-                    </td>
-
-                    <td class="posted">
-                        ${info.datePosted}<br>
-                        Some location
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    `;
-};
+const scraperSpy = jest.spyOn(scraper, "scrape");
+const getAPIPageResultsSpy = jest.spyOn(APISearcher.prototype, "getPageResults");
+const getHTMLPageResultsSpy = jest.spyOn(HTMLSearcher.prototype, "getPageResults");
 
 describe.each`
-    markup                           | createResultHTML
-    ${"standard result page markup"} | ${createStandardResultHTML}
-    ${"service result page markup"}  | ${createServiceResultHTML}
-`("Search result HTML scraper ($markup)", ({ createResultHTML }) => {
+    scraperType
+    ${helpers.ScraperType.API}
+    ${helpers.ScraperType.HTML}
+`("Ad searcher (scraperType=$scraperType)", ({ scraperType }) => {
+    const activeSearcher = scraperType === helpers.ScraperType.API
+        ? getAPIPageResultsSpy
+        : getHTMLPageResultsSpy;
+    const allSearchers = [
+        getAPIPageResultsSpy,
+        getHTMLPageResultsSpy
+    ];
+
+    const getScraperOptionsSpy = jest.spyOn(helpers, "getScraperOptions");
+
+    beforeEach(() => {
+        getScraperOptionsSpy.mockReturnValue({ scraperType });
+    });
+
     afterEach(() => {
         jest.resetAllMocks();
     });
-
-    const validateSearchUrl = (url: string, expectedParams: SearchParameters) => {
-        const splitUrl = url.split("?");
-        expect(splitUrl.length).toBe(2);
-        expect(splitUrl[0]).toBe("https://www.kijiji.ca/b-search.html")
-        expect(qs.parse(splitUrl[1])).toEqual(qs.parse(qs.stringify(expectedParams)));
-    };
 
     const defaultSearchParams: SearchParameters = {
         locationId: 0,
@@ -117,15 +38,42 @@ describe.each`
         formSubmit: true,
         siteLocale: "en_CA"
     };
+
+    const expectSearcherCall = (expected: SearchParameters = defaultSearchParams) => {
+        expect(activeSearcher).toBeCalledWith(expected, 1);
+        allSearchers.forEach(s => {
+            if (s !== activeSearcher) {
+                expect(s).not.toBeCalled();
+            }
+        });
+    };
+
+    it("should catch search errors", async () => {
+        activeSearcher.mockImplementationOnce(() => { throw new Error("Error searching"); });
+
+        try {
+            await search({});
+            fail("Expected error while searching");
+        } catch (err) {
+            expect(err.message).toBe(
+                "Error parsing Kijiji search results: Error searching. " +
+                "It is possible that Kijiji changed their markup. " +
+                "If you believe this to be the case, please open an issue at: " +
+                "https://github.com/mwpenny/kijiji-scraper/issues"
+            );
+        }
+    });
+
     describe("search parameters", () => {
         it("should use default values if none are specified", async () => {
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+            activeSearcher.mockResolvedValueOnce({
+                pageResults: [],
+                isLastPage: true
+            });
 
             await search({});
 
-            expect(fetchSpy).toBeCalled();
-            validateSearchUrl(fetchSpy.mock.calls[0][0], defaultSearchParams);
+            expectSearcherCall(defaultSearchParams);
         });
 
         describe.each`
@@ -147,42 +95,56 @@ describe.each`
                     fail(`Expected error for bad ${param}`);
                 } catch (err) {
                     expect(err.message).toBe(`Integer property '${param}' must be specified`);
-                    expect(fetchSpy).not.toBeCalled();
+                    allSearchers.forEach(s => expect(s).not.toBeCalled());
                 }
             });
 
             it("should allow integers", async () => {
-                fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-                fetchSpy.mockResolvedValueOnce({ text: () => "" });
+                activeSearcher.mockResolvedValueOnce({
+                    pageResults: [],
+                    isLastPage: true
+                });
 
                 await search({ [param]: (useObject ? { id: 123 } : 123) });
 
-                expect(fetchSpy).toBeCalled();
-                validateSearchUrl(fetchSpy.mock.calls[0][0], {
+                expectSearcherCall({
                     ...defaultSearchParams,
                     [param]: 123
                 });
             });
         });
 
-        it("should pass all defined params in search URL", async () => {
+        it("should pass all defined params to searcher", async () => {
             const params = { ...defaultSearchParams };
             params.locationId = 123;
             params.categoryId = 456;
             params.someOtherParam = "hello";
             params.undef = undefined;
 
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+            activeSearcher.mockResolvedValueOnce({
+                pageResults: [],
+                isLastPage: true
+            });
 
             await search(params);
 
-            expect(fetchSpy).toBeCalled();
-            validateSearchUrl(fetchSpy.mock.calls[0][0], params);
+            expectSearcherCall(params);
         });
     });
 
     describe("search options", () => {
+        it("should not search if retrieving options throws error", async () => {
+            getScraperOptionsSpy.mockImplementation(() => { throw new Error("Bad options"); });
+
+            try {
+                await search({});
+                fail("Expected error for bad scraper options");
+            } catch (err) {
+                expect(err.message).toBe("Bad options");
+                allSearchers.forEach(s => expect(s).not.toBeCalled());
+            }
+        });
+
         describe.each`
             option
             ${"minResults"}
@@ -200,17 +162,19 @@ describe.each`
                     fail(`Expected error for bad ${option}`);
                 } catch (err) {
                     expect(err.message).toBe(`Integer property '${option}' must be specified`);
-                    expect(fetchSpy).not.toBeCalled();
+                    allSearchers.forEach(s => expect(s).not.toBeCalled());
                 }
             });
 
             it("should allow integers", async () => {
-                fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-                fetchSpy.mockResolvedValueOnce({ text: () => "" });
+                activeSearcher.mockResolvedValueOnce({
+                    pageResults: [],
+                    isLastPage: true
+                });
 
                 await search({}, { [option]: 123 });
 
-                expect(fetchSpy).toBeCalledTimes(2);
+                expectSearcherCall();
             });
         });
 
@@ -220,26 +184,46 @@ describe.each`
                 ${"true by default"} | ${undefined}
                 ${"explicitly true"} | ${true}
             `("should scrape result details if true ($test)", async ({ value }) => {
-                fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-                fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ path: "/myad" }) });
-                fetchSpy.mockResolvedValueOnce({ text: () => "" });
+                activeSearcher.mockResolvedValueOnce({
+                    pageResults: [new Ad("http://example.com")],
+                    isLastPage: true
+                });
+
                 scraperSpy.mockResolvedValueOnce({ title: "My title" } as scraper.AdInfo);
 
-                const ads = await search({}, { scrapeResultDetails: value });
+                const ads = await search({}, { scrapeResultDetails: value, scraperType });
 
-                expect(scraperSpy).toBeCalledWith("https://www.kijiji.ca/myad");
+                expectSearcherCall();
+                expect(scraperSpy).toBeCalledWith("http://example.com", undefined);
                 expect(ads).toEqual([expect.objectContaining({
                     title: "My title"
                 })]);
             });
 
             it("should not scrape result details if false", async () => {
-                fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-                fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ path: "/myad" }) });
-                fetchSpy.mockResolvedValueOnce({ text: () => "" });
+                activeSearcher.mockResolvedValueOnce({
+                    pageResults: [new Ad("")],
+                    isLastPage: true
+                });
 
-                const ads = await search({}, { scrapeResultDetails: false });
+                const ads = await search({}, { scrapeResultDetails: false, scraperType });
 
+                expectSearcherCall();
+                expect(scraperSpy).not.toBeCalled();
+                expect(ads).toEqual([expect.objectContaining({
+                    title: ""
+                })]);
+            });
+
+            it("should not scrape result details if already scraped", async () => {
+                activeSearcher.mockResolvedValueOnce({
+                    pageResults: [new Ad("", undefined, true)],
+                    isLastPage: true
+                });
+
+                const ads = await search({}, { scrapeResultDetails: true, scraperType });
+
+                expectSearcherCall();
                 expect(scraperSpy).not.toBeCalled();
                 expect(ads).toEqual([expect.objectContaining({
                     title: ""
@@ -249,17 +233,24 @@ describe.each`
 
         it.each`
             test                      | value        | expectedRequestCount
-            ${"default value of 40"}  | ${undefined} | ${40}
+            ${"default value of 20"}  | ${undefined} | ${20}
             ${"explicitly set to 5"}  | ${5}         | ${5}
             ${"explicitly set to 0"}  | ${0}         | ${0}
             ${"explicitly set to -1"} | ${-1}        | ${0}
         `("should stop scraping if minResults ads are found ($test)", async ({ value, expectedRequestCount }) => {
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-            fetchSpy.mockResolvedValue({ text: () => createResultHTML({}) });
+            activeSearcher.mockResolvedValue({
+                pageResults: [new Ad("")],
+                isLastPage: false
+            });
 
             const ads = await search({}, { scrapeResultDetails: false, minResults: value });
             expect(ads.length).toBe(expectedRequestCount);
-            expect(fetchSpy).toBeCalledTimes(expectedRequestCount + 1);
+            expect(activeSearcher).toBeCalledTimes(expectedRequestCount);
+            allSearchers.forEach(s => {
+                if (s !== activeSearcher) {
+                    expect(s).not.toBeCalled();
+                }
+            });
         });
 
         it.each`
@@ -268,249 +259,51 @@ describe.each`
             ${"explicitly set to -1"} | ${5}         | ${5}
             ${"explicitly set to 3"}  | ${3}         | ${3}
         `("should truncate results based on maxResults ($test)", async ({ value, expectedResultCount }) => {
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
+            activeSearcher.mockResolvedValueOnce({ pageResults: [new Ad("")], isLastPage: false });
+            activeSearcher.mockResolvedValueOnce({ pageResults: [new Ad("")], isLastPage: false });
+            activeSearcher.mockResolvedValueOnce({ pageResults: [new Ad("")], isLastPage: false });
+            activeSearcher.mockResolvedValueOnce({ pageResults: [new Ad("")], isLastPage: false });
+            activeSearcher.mockResolvedValueOnce({ pageResults: [new Ad("")], isLastPage: true });
 
             const ads = await search({}, { scrapeResultDetails: false, maxResults: value });
+
             expect(ads.length).toBe(expectedResultCount);
-            expect(fetchSpy).toBeCalledTimes(7);
-        });
-    });
-
-    describe("result page redirect", () => {
-        it.each`
-            test                       | response
-            ${"non-200 response code"} | ${{ status: 418 }}
-            ${"no redirect"}           | ${{ status: 200 }}
-        `("should throw error for bad response ($test)", async ({ response }) => {
-            fetchSpy.mockResolvedValue(response);
-
-            try {
-                await search({});
-                fail("Expected error for non-200 response code");
-            } catch (err) {
-                expect(err.message).toBe(
-                    "Kijiji failed to return search results. " +
-                    "It is possible that Kijiji changed their " +
-                    "results markup. If you believe this to be " +
-                    "the case, please open a bug at: " +
-                    "https://github.com/mwpenny/kijiji-scraper/issues"
-                );
+            for (let i = 1; i <= 5; ++i) {
+                expect(activeSearcher).toHaveBeenNthCalledWith(i, defaultSearchParams, i);
             }
-        });
-
-        it("should be used for pagination", async () => {
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            await search({}, { scrapeResultDetails: false });
-
-            expect(fetchSpy).toBeCalledTimes(3);
-            validateSearchUrl(fetchSpy.mock.calls[0][0], defaultSearchParams);
-            expect(fetchSpy.mock.calls.slice(1)).toEqual([
-                ["http://example.com/search/page-1/results"],
-                ["http://example.com/search/page-2/results"]
-            ]);
-        });
-    });
-
-    describe("result page scraping", () => {
-        // Helpers for date tests
-        const nanDataValidator = (date: Date) => {
-            expect(Number.isNaN(date.getTime())).toBe(true);
-        };
-        const makeSpecificDateValidator = (month: number, day: number, year: number) => {
-            return (date: Date) => {
-                const d = new Date();
-                d.setMonth(month - 1);
-                d.setDate(day);
-                d.setFullYear(year);
-                d.setHours(0, 0, 0, 0);
-
-                expect(date).toEqual(d);
-            }
-        };
-        const makeMinutesAgoValidator = (minutes: number) => {
-            return (date: Date) => {
-                const minutesAgo = new Date();
-                minutesAgo.setMinutes(minutesAgo.getMinutes() - minutes, 0, 0);
-
-                expect(date).toEqual(minutesAgo);
-            }
-        };
-        const makeHoursAgoValidator = (hours: number) => {
-            return (date: Date) => {
-                const hoursAgo = new Date();
-                hoursAgo.setHours(hoursAgo.getHours() - hours, 0, 0, 0);
-
-                expect(date).toEqual(hoursAgo);
-            }
-        };
-        const makeDaysAgoValidator = (days: number) => {
-            return (date: Date) => {
-                const daysAgo = new Date();
-                daysAgo.setDate(daysAgo.getDate() - days);
-                daysAgo.setHours(0, 0, 0, 0);
-
-                expect(date).toEqual(daysAgo);
-            }
-        };
-        const nowIshValidator = (date: Date) => {
-            const nowIsh = new Date();
-            nowIsh.setSeconds(date.getSeconds());
-            nowIsh.setMilliseconds(date.getMilliseconds());
-
-            expect(date).toEqual(nowIsh);
-        };
-
-        beforeEach(() => {
-            fetchSpy.mockResolvedValueOnce({ status: 200, url: "http://example.com/search/results" });
-        });
-
-        it("should throw error if scraping fails", async () => {
-            const warnSpy = jest.spyOn(console, "warn").mockImplementationOnce(() => {});
-            const loadSpy = jest.spyOn(cheerio, "load");
-            loadSpy.mockImplementationOnce(() => { throw new Error("Catastrophe"); });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-
-            try {
-                await search({});
-                fail("Expected error while scraping results page");
-            } catch (err) {
-                expect(err.message).toBe("Invalid Kijiji HTML on search results page (http://example.com/search/page-1/results)");
-                expect(warnSpy).toBeCalledWith("WARNING: Failed to parse search result: Error: Catastrophe");
-                loadSpy.mockRestore();
-                warnSpy.mockRestore();
-            }
-        });
-
-        it("should scrape title", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ title: "My title" }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads).toEqual([expect.objectContaining({
-                title: "My title"
-            })]);
-        });
-
-        it.each`
-            test                    | imageAttributes                   | expectedValue
-            ${"with data-src"}      | ${'data-src="/image" src="blah"'} | ${"/image"}
-            ${"with src"}           | ${'data-src="" src="/image"'}     | ${"/image"}
-            ${"with no attributes"} | ${""}                             | ${""}
-            ${"upsize"}             | ${'src="/image/s-l123.jpg"'}      | ${"/image/s-l2000.jpg"}
-        `("should scrape image ($test)", async ({ imageAttributes, expectedValue }) => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ imageAttributes }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads).toEqual([expect.objectContaining({
-                image: expectedValue
-            })]);
-        });
-
-        it.each`
-            test             | datePosted           | validator
-            ${"no date"}     | ${""}                | ${nanDataValidator}
-            ${"invalid"}     | ${"invalid"}         | ${nanDataValidator}
-            ${"dd/mm/yyyy"}  | ${"7/9/2020"}        | ${makeSpecificDateValidator(9, 7, 2020)}
-            ${"minutes ago"} | ${"< 5 minutes ago"} | ${makeMinutesAgoValidator(5)}
-            ${"hours ago"}   | ${"< 2 hours ago"}   | ${makeHoursAgoValidator(2)}
-            ${"invalid ago"} | ${"< 1 parsec ago"}  | ${nowIshValidator}
-            ${"yesterday"}   | ${"yesterday"}       | ${makeDaysAgoValidator(1)}
-        `("should scrape date ($test)", async ({ datePosted, validator }) => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ datePosted }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads.length).toBe(1);
-            validator(ads[0].date);
-        });
-
-        it("should scrape description", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ description: "My desc" }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads).toEqual([expect.objectContaining({
-                description: "My desc"
-            })]);
-        });
-
-        it("should scrape url", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ path: "/myad" }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads).toEqual([expect.objectContaining({
-                url: "https://www.kijiji.ca/myad"
-            })]);
-        });
-
-        it("should exclude featured ads", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) + createResultHTML({ isFeatured: true }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads.length).toBe(1);
-        });
-
-        it("should exclude third-party ads", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) + createResultHTML({ isThirdParty: true }) });
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads.length).toBe(1);
-        });
-
-        it("should stop scraping on last page", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) });
-            fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({}) + '"isLastPage":true' });
-
-            const ads = await search({}, { scrapeResultDetails: false });
-            expect(ads.length).toBe(2);
-            expect(fetchSpy).toBeCalledTimes(3);
-        });
-
-        it("should stop scraping if no results are found", async () => {
-            fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-            const ads = await search({});
-            expect(ads.length).toBe(0);
-            expect(fetchSpy).toBeCalledTimes(2);
-        });
-
-        describe("callback", () => {
-            it("should be called on success", async () => {
-                fetchSpy.mockResolvedValueOnce({ text: () => createResultHTML({ title: "My title" }) });
-                fetchSpy.mockResolvedValueOnce({ text: () => "" });
-
-                const callback = jest.fn();
-                const ads = await search({}, { scrapeResultDetails: false }, callback);
-
-                expect(callback).toBeCalledWith(null, ads);
-            });
-
-            it("should be called on error", async () => {
-                fetchSpy.mockImplementationOnce(() => { throw new Error("Bad fetch"); });
-
-                const callback = jest.fn();
-
-                try {
-                    await search({}, {}, callback);
-                    fail("Expected error");
-                } catch (error) {
-                    expect(error.message).toBe("Bad fetch");
-                    expect(callback).toBeCalledWith(expect.objectContaining({ message: "Bad fetch" }), []);
+            allSearchers.forEach(s => {
+                if (s !== activeSearcher) {
+                    expect(s).not.toBeCalled();
                 }
             });
+        });
+    });
+
+    describe("callback", () => {
+        it("should be called on success", async () => {
+            activeSearcher.mockResolvedValueOnce({
+                pageResults: [new Ad("")],
+                isLastPage: true
+            });
+
+            const callback = jest.fn();
+            const ads = await search({}, { scrapeResultDetails: false }, callback);
+
+            expectSearcherCall();
+            expect(callback).toBeCalledWith(null, ads);
+        });
+
+        it("should be called on error", async () => {
+            activeSearcher.mockImplementationOnce(() => { throw new Error("Bad search"); });
+
+            const callback = jest.fn();
+
+            try {
+                await search({}, {}, callback);
+                fail("Expected error");
+            } catch (error) {
+                expect(callback).toBeCalledWith(expect.any(Error), []);
+            }
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The mobile API will be used by default but you can use the old method if you want by using the new [Scraper Options](https://github.com/mwpenny/kijiji-scraper#scraper-options) type. `Ad.Get()` takes it as an [argument](https://github.com/mwpenny/kijiji-scraper#adgeturl-options-callback) and `search()` accepts the `scraperType` property in the existing `options` argument. Note that some [search parameters](https://github.com/mwpenny/kijiji-scraper#searchparams-options-callback) are affected by this change (e.g., `params.keywords` -> `params.q`).

When using the mobile API, I try to appear the same as the Android app by sending the same HTTP headers. When using the website, I sent a `User-Agent` header indicating Firefox on Windows.

I've also added configurable rate limiting. When searching, `pageDelayMs` can be used to add a delay between each page of results. Its value is `1000` by default. When `scrapeResultDetails` is set to `true`, `resultDetailsDelayMs` can be used to add a delay in between each request for details (note that this forces the requests to be executed serially rather than in parallel like they were up until now - a value of `0` is the same as the old behavior). One nice thing about the mobile API is that result details are part of the search results so `scrapeResultDetails` is actually unnecessary if using the mobile API (if `true` in that case it will have no effect).

Finally, the module will detect if you get blocked and throw an error letting you know. I was unable to get myself banned using the mobile API but to be fair, I didn't try to hard. This is good to have anyway.