### PR TITLE
Use attr() to get attributes instead of reading raw attribs object

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
@technoligest While writing tests I found a way to do it which requires no additional branching :)

Usage of `attribs` is a holdover from when I wrote the first version of this in 2015 and Cheerio was less mature (and so was I, evidently, haha). Cheerios has the jQuery-like `attr()` which we can use.