### PR TITLE
When using the API scraper, skip ads with no self-public-website URL

### DIFF
--- a/lib/backends/api-searcher.ts
+++ b/lib/backends/api-searcher.ts
@@ -22,7 +22,8 @@ function parseResultsXML(xml: string): Ad[] {
     $("ad\\:ad").each((_i, item) => {
         const url = $(item).find("ad\\:link[rel='self-public-website']").attr("href");
         if (!url) {
-            throw new Error(`Result ad has no URL. ${POSSIBLE_BAD_MARKUP}`);
+            // Top and third-party ads have no Kijiji URL
+            return;
         }
 
         const info = scrapeAdElement(item);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Top ads, for example, can be missing this.