### PR TITLE
Fix parsing of boolean and numeric attributes

### DIFF
--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -11,15 +11,20 @@ import { AdInfo } from "../scraper";
 const AD_ID_REGEX = /\/(\d+)$/;
 const API_ADS_ENDPOINT = "https://mingle.kijiji.ca/api/ads";
 
-function castAttributeValue(item: cheerio.Cheerio, value: string): boolean | number | Date | string {
-    // Kijiji only returns strings for attributes. Convert to appropriate types
-    const type = (item.attr("type") || "").toLowerCase();
-    const localizedLabel = (item.attr("localized-label") || "").toLowerCase();
-    value = value.trim();
+function castAttributeValue(item: cheerio.Cheerio): boolean | number | Date | string | undefined {
+    const valueElem = item.find("attr\\:value");
+    if (valueElem.length === 0) {
+        return undefined;
+    }
 
-    if (localizedLabel === "yes") {
+    const type = (item.attr("type") || "").toLowerCase();
+    const value = valueElem.text().trim();
+    const localizedValue = (valueElem.attr("localized-label") || "").toLowerCase();
+
+    // Kijiji only returns strings for attributes. Convert to appropriate types
+    if (localizedValue === "yes") {
         return true;
-    } else if (localizedLabel === "no") {
+    } else if (localizedValue === "no") {
         return false;
     } else if (isNumber(value)) {
         return Number(value);
@@ -69,9 +74,9 @@ export function scrapeAdElement(elem: cheerio.Element): AdInfo | null {
     $("attr\\:attribute").each((_i, item) => {
         const cheerioItem = $(item);
         const name = cheerioItem.attr("name");
-        const value = cheerioItem.find("attr\\:value").text();
-        if (name && value) {
-            info.attributes[name] = castAttributeValue(cheerioItem, value);
+        const value = castAttributeValue(cheerioItem);
+        if (name && value !== undefined) {
+            info.attributes[name] = value;
         }
     });
 

--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -27,6 +27,11 @@ function castAttributeValue(item: cheerio.Cheerio): boolean | number | Date | st
     } else if (localizedValue === "no") {
         return false;
     } else if (isNumber(value)) {
+        // Numeric values are sometimes inaccurate. For example, numberbathrooms
+        // is multipled by 10. Prefer localized version if it is also a number.
+        if (isNumber(localizedValue)) {
+            return Number(localizedValue);
+        }
         return Number(value);
     } else if (type === "date") {
         return new Date(value);

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -51,12 +51,13 @@ describe("Ad API scraper", () => {
         return `
             <attr:attribute
                 name="${name}"
-                ${typeof value === "boolean" ? `localized-label=${value ? "Yes" : "No"}` : ""}
                 ${value instanceof Date ? 'type="DATE"' : ""}
             >
                 ${value !== undefined ?
                     `
-                        <attr:value>
+                        <attr:value
+                            ${typeof value === "boolean" ? `localized-label=${value ? "Yes" : "No"}` : ""}
+                        >
                         ${
                             value instanceof Date ? value.toISOString() :
                             typeof value === "string" ? value :
@@ -264,6 +265,7 @@ describe("Ad API scraper", () => {
             ${"float"}         | ${1.21}
             ${"date"}          | ${new Date("2020-09-06T20:52:47.474Z")}
             ${"string"}        | ${"hello"}
+            ${"empty string"}  | ${""}
         `("should scrape attribute ($test)", async ({ value }) => {
             mockResponse(createAdXML({
                 title: "My ad title",

--- a/lib/backends/test/html-searcher.spec.ts
+++ b/lib/backends/test/html-searcher.spec.ts
@@ -116,6 +116,7 @@ describe.each`
                 expect.any(String),
                 {
                     headers: {
+                        "Accept-Language": "en-CA",
                         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0"
                     }
                 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,6 +2,7 @@ const BUGS_URL = "https://github.com/mwpenny/kijiji-scraper/issues";
 
 // I'm not sure how much this helps with getting banned, but it seems to
 export const HTML_REQUEST_HEADERS = {
+    "Accept-Language": "en-CA",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0"
 };
 

--- a/lib/test/helpers.spec.ts
+++ b/lib/test/helpers.spec.ts
@@ -36,6 +36,7 @@ describe("Helpers", () => {
         ${" "}        | ${false}
         ${"abc123"}   | ${false}
         ${"1.2.3"}    | ${false}
+        ${"4 1/2"}    | ${false}
         ${"Infinity"} | ${false}
         ${"abc"}      | ${false}
     `("isNumber should detect numbers (input='$input')", ({ input, expectedResult }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Fix boolean attribute parsing when using the API-based scraper
* Use the English locale-specific value for numeric attributes IFF it is also a number (handles floating point values stored as multiplied integers such as `numberbathrooms`)