### PR TITLE
Fix date attribute parsing for HTML scraper (#61)

### DIFF
--- a/lib/backends/html-scraper.ts
+++ b/lib/backends/html-scraper.ts
@@ -29,7 +29,7 @@ function castAttributeValue(attr: any): boolean | number | Date | string | undef
             return Number(localizedValue);
         }
         return Number(value);
-    } else if (!isNaN(Date.parse(value))) {
+    } else if (!isNaN(Date.parse(value)) && isNumber(value[0])) {
         return new Date(value);
     } else {
         return value;

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -225,15 +225,17 @@ describe("Ad HTML scraper", () => {
 
         describe("attribute scraping", () => {
             it.each`
-                test               | value                         | expectedValue
-                ${"undefined"}     | ${undefined}                  | ${undefined}
-                ${"true boolean"}  | ${"true"}                     | ${true}
-                ${"false boolean"} | ${"false"}                    | ${false}
-                ${"integer"}       | ${"123"}                      | ${123}
-                ${"float"}         | ${"1.21"}                     | ${1.21}
-                ${"date"}          | ${"2020-09-06T20:52:47.474Z"} | ${new Date("2020-09-06T20:52:47.474Z")}
-                ${"string"}        | ${"hello"}                    | ${"hello"}
-                ${"empty string"}  | ${""}                         | ${""}
+                test                | value                            | expectedValue
+                ${"undefined"}      | ${undefined}                     | ${undefined}
+                ${"true boolean"}   | ${"true"}                        | ${true}
+                ${"false boolean"}  | ${"false"}                       | ${false}
+                ${"integer"}        | ${"123"}                         | ${123}
+                ${"float"}          | ${"1.21"}                        | ${1.21}
+                ${"date"}           | ${"2020-09-06T20:52:47.474Z"}    | ${new Date("2020-09-06T20:52:47.474Z")}
+                ${"preciseDate"}    | ${"2021-05-06T00:00:54.978123Z"} | ${new Date("2021-05-06T00:00:54.978123Z")}
+                ${"string"}         | ${"hello"}                       | ${"hello"}
+                ${"datelikeString"} | ${"blah-2021-05-05"}             | ${"blah-2021-05-05"}
+                ${"empty string"}   | ${""}                            | ${""}
             `("should scrape attribute ($test)", async ({ value, expectedValue }) => {
                 mockResponse(createAdHTML({
                     config: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Permissive date parsing means that strings like "size-10" are considered
valid date strings ("size-" is ignored, and "10" is treated as number of
months since January 1, 2000).

Kijiji uses ISO-style date strings, so reject dates whose raw value
begins with a non-numeric characters.