### PR TITLE
Fixes for newer versions of Node.js and TypeScript

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - name: Checkout code

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -110,7 +110,8 @@ describe("Ad API scraper", () => {
             await scraper(FAKE_VALID_AD_URL);
             fail("Expected error for ban");
         } catch (err) {
-            expect(err.message).toBe(
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(
                 "Kijiji denied access. You are likely temporarily blocked. This " +
                 "can happen if you scrape too aggressively. Try scraping again later, " +
                 "and more slowly. If this happens even when scraping reasonably, please " +
@@ -146,9 +147,11 @@ describe("Ad API scraper", () => {
         try {
             await scraper(FAKE_VALID_AD_URL);
             fail("Expected API error");
-        } catch (error) {
+        } catch (err) {
             validateRequest();
-            expect(error.message).toBe("Kijiji returned error: Scraped knee!");
+
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe("Kijiji returned error: Scraped knee!");
         }
     });
 
@@ -158,7 +161,7 @@ describe("Ad API scraper", () => {
                 await scraper("not a URL")
                 fail("Expected error for invalid URL");
             } catch (err) {
-                expect(err.message).toEqual(expect.stringContaining("Invalid URL"));
+                expect((err as Error).message).toEqual(expect.stringContaining("Invalid URL"));
             }
         });
 
@@ -167,7 +170,10 @@ describe("Ad API scraper", () => {
                 await scraper("http://example.com")
                 fail("Expected error for invalid URL");
             } catch (err) {
-                expect(err.message).toBe("Invalid Kijiji ad URL. Ad URLs must end in /some-ad-id.");
+                expect(err).toBeInstanceOf(Error);
+                expect((err as Error).message).toBe(
+                    "Invalid Kijiji ad URL. Ad URLs must end in /some-ad-id."
+                );
             }
         });
 

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -158,7 +158,7 @@ describe("Ad API scraper", () => {
                 await scraper("not a URL")
                 fail("Expected error for invalid URL");
             } catch (err) {
-                expect(err.message).toBe("Invalid URL: not a URL");
+                expect(err.message).toEqual(expect.stringContaining("Invalid URL"));
             }
         });
 

--- a/lib/backends/test/api-searcher.spec.ts
+++ b/lib/backends/test/api-searcher.spec.ts
@@ -79,7 +79,8 @@ describe("Search result API scraper", () => {
             await search();
             fail("Expected error for ban");
         } catch (err) {
-            expect(err.message).toBe(
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(
                 "Kijiji denied access. You are likely temporarily blocked. This " +
                 "can happen if you scrape too aggressively. Try scraping again later, " +
                 "and more slowly. If this happens even when scraping reasonably, please " +
@@ -115,7 +116,8 @@ describe("Search result API scraper", () => {
                 await search();
                 fail("Expected error while scraping results page");
             } catch (err) {
-                expect(err.message).toBe(
+                expect(err).toBeInstanceOf(Error);
+                expect((err as Error).message).toBe(
                     "Result ad could not be parsed. It is possible that Kijiji " +
                     "changed their markup. If you believe this to be the case, " +
                     "please open an issue at: https://github.com/mwpenny/kijiji-scraper/issues"

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -48,7 +48,8 @@ describe("Ad HTML scraper", () => {
             await scraper("http://example.com");
             fail("Expected error for ban");
         } catch (err) {
-            expect(err.message).toBe(
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(
                 "Kijiji denied access. You are likely temporarily blocked. This " +
                 "can happen if you scrape too aggressively. Try scraping again later, " +
                 "and more slowly. If this happens even when scraping reasonably, please " +

--- a/lib/backends/test/html-searcher.spec.ts
+++ b/lib/backends/test/html-searcher.spec.ts
@@ -151,7 +151,8 @@ describe.each`
             await search();
             fail("Expected error for ban");
         } catch (err) {
-            expect(err.message).toBe(
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(
                 "Kijiji denied access. You are likely temporarily blocked. This " +
                 "can happen if you scrape too aggressively. Try scraping again later, " +
                 "and more slowly. If this happens even when scraping reasonably, please " +
@@ -193,7 +194,8 @@ describe.each`
                 await search();
                 fail("Expected error for non-200 response code");
             } catch (err) {
-                expect(err.message).toBe(
+                expect(err).toBeInstanceOf(Error);
+                expect((err as Error).message).toBe(
                     "Kijiji failed to redirect to results page. It is possible " +
                     "that Kijiji changed their markup. If you believe this to be " +
                     "the case, please open an issue at: " +
@@ -283,7 +285,8 @@ describe.each`
                 await search();
                 fail("Expected error while scraping results page");
             } catch (err) {
-                expect(err.message).toBe(
+                expect(err).toBeInstanceOf(Error);
+                expect((err as Error).message).toBe(
                     "Result ad has no URL. It is possible that Kijiji changed their " +
                     "markup. If you believe this to be the case, please open an issue " +
                     "at: https://github.com/mwpenny/kijiji-scraper/issues"

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -148,7 +148,11 @@ async function getSearchResults(searcher: Searcher, params: ResolvedSearchParame
             }
         }
     } catch (err) {
-        throw new Error(`Error parsing Kijiji search results: ${err.message}`);
+        let message = "Error parsing Kijiji search results";
+        if (err instanceof Error) {
+            message += `: ${err.message}`;
+        }
+        throw new Error(message);
     }
     return results;
 }

--- a/lib/test/helpers.spec.ts
+++ b/lib/test/helpers.spec.ts
@@ -70,7 +70,10 @@ describe("Helpers", () => {
                     getScraperOptions(scraperOptions);
                     fail("Expected error for bad scraper options");
                 } catch (err) {
-                    expect(err.message).toBe("Invalid value for scraper option 'scraperType'. Valid values are: api, html");
+                    expect(err).toBeInstanceOf(Error);
+                    expect((err as Error).message).toBe(
+                        "Invalid value for scraper option 'scraperType'. Valid values are: api, html"
+                    );
                 }
             });
 

--- a/lib/test/scraper.spec.ts
+++ b/lib/test/scraper.spec.ts
@@ -40,7 +40,8 @@ describe.each`
             await scrape(url);
             fail("Expected error for bad URL");
         } catch (err) {
-            expect(err.message).toBe("URL must be specified");
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe("URL must be specified");
             allScrapers.forEach(s => expect(s).not.toBeCalled());
         }
     });
@@ -52,7 +53,8 @@ describe.each`
             await scrape(url);
             fail("Expected error for no ad info");
         } catch (err) {
-            expect(err.message).toBe(
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(
                 "Ad not found or invalid response received from Kijiji for " +
                 "ad at http://example.com. It is possible that Kijiji changed " +
                 "their markup. If you believe this to be the case, please open " +
@@ -74,7 +76,8 @@ describe.each`
             await scrape("http://example.com", {});
             fail("Expected error for bad scraper options");
         } catch (err) {
-            expect(err.message).toBe("Bad options");
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe("Bad options");
             allScrapers.forEach(s => expect(s).not.toBeCalled());
         }
     });

--- a/lib/test/search.spec.ts
+++ b/lib/test/search.spec.ts
@@ -65,7 +65,9 @@ describe.each`
             if (toThrow instanceof Error) {
                 expectedMessage += `: Error searching`;
             }
-            expect(err.message).toBe(expectedMessage);
+
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error).message).toBe(expectedMessage);
         }
     });
 
@@ -99,7 +101,10 @@ describe.each`
                     await search({ [param]: (useObject ? { id } : id) });
                     fail(`Expected error for bad ${param}`);
                 } catch (err) {
-                    expect(err.message).toBe(`Integer property '${param}' must be specified`);
+                    expect(err).toBeInstanceOf(Error);
+                    expect((err as Error).message).toBe(
+                        `Integer property '${param}' must be specified`
+                    );
                     allSearchers.forEach(s => expect(s).not.toBeCalled());
                 }
             });
@@ -145,7 +150,8 @@ describe.each`
                 await search({});
                 fail("Expected error for bad scraper options");
             } catch (err) {
-                expect(err.message).toBe("Bad options");
+                expect(err).toBeInstanceOf(Error);
+                expect((err as Error).message).toBe("Bad options");
                 allSearchers.forEach(s => expect(s).not.toBeCalled());
             }
         });
@@ -168,7 +174,10 @@ describe.each`
                     await search({}, { [option]: value });
                     fail(`Expected error for bad ${option}`);
                 } catch (err) {
-                    expect(err.message).toBe(`Integer property '${option}' must be specified`);
+                    expect(err).toBeInstanceOf(Error);
+                    expect((err as Error).message).toBe(
+                        `Integer property '${option}' must be specified`
+                    );
                     allSearchers.forEach(s => expect(s).not.toBeCalled());
                 }
             });

--- a/lib/test/search.spec.ts
+++ b/lib/test/search.spec.ts
@@ -50,16 +50,22 @@ describe.each`
         });
     };
 
-    it("should catch search errors", async () => {
-        activeSearcher.mockImplementationOnce(() => { throw new Error("Error searching"); });
+    it.each`
+        test                 | toThrow
+        ${"Throw Error"}     | ${new Error("Error searching")}
+        ${"Throw non-Error"} | ${1234}
+    `("should catch search errors ($test)", async ({ toThrow }) => {
+        activeSearcher.mockImplementationOnce(() => { throw toThrow; });
 
         try {
             await search({});
             fail("Expected error while searching");
         } catch (err) {
-            expect(err.message).toBe(
-                "Error parsing Kijiji search results: Error searching"
-            );
+            let expectedMessage = "Error parsing Kijiji search results";
+            if (toThrow instanceof Error) {
+                expectedMessage += `: Error searching`;
+            }
+            expect(err.message).toBe(expectedMessage);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Update invalid URL test for API scraper to handle slightly different error message in current versions of Node
* Handle non-`Error` objects thrown when searching, and in tests
* Do not mock `setTimeout()` in `sleep()` (use fake timers instead)
* Drop Node 10.x from the CI workflow and add Node 16.x (the current LTS)