### PR TITLE
Fix attribute handling

### DIFF
--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -108,7 +108,7 @@ export function scrapeAdElement(elem: cheerio.Element): AdInfo | null {
     }
 
     const viewCount = $("ad\\:view-ad-count").text();
-    if (viewCount) {
+    if (isNumber(viewCount)) {
         info.attributes["visits"] = Number(viewCount);
     }
     return info;

--- a/lib/backends/api-scraper.ts
+++ b/lib/backends/api-scraper.ts
@@ -22,10 +22,8 @@ function castAttributeValue(item: cheerio.Cheerio): boolean | number | Date | st
     const localizedValue = (valueElem.attr("localized-label") || "").toLowerCase();
 
     // Kijiji only returns strings for attributes. Convert to appropriate types
-    if (localizedValue === "yes") {
-        return true;
-    } else if (localizedValue === "no") {
-        return false;
+    if (type === "boolean" || ["yes", "no"].includes(localizedValue)) {
+        return value === "1";
     } else if (isNumber(value)) {
         // Numeric values are sometimes inaccurate. For example, numberbathrooms
         // is multipled by 10. Prefer localized version if it is also a number.

--- a/lib/backends/html-scraper.ts
+++ b/lib/backends/html-scraper.ts
@@ -18,10 +18,8 @@ function castAttributeValue(attr: any): boolean | number | Date | string | undef
     const localizedValue = (attr.localeSpecificValues?.en?.value || "").toLowerCase();
 
     // Kijiji only returns strings. Convert to appropriate types
-    if (value.toLowerCase() === "true") {
-        return true;
-    } else if (value.toLowerCase() === "false") {
-        return false;
+    if (attr.booleanAttribute || ["yes", "no"].includes(localizedValue)) {
+        return value === "1";
     } else if (isNumber(value)) {
         // Numeric values are sometimes inaccurate. For example, numberbathrooms
         // is multipled by 10. Prefer localized version if it is also a number.

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -429,19 +429,24 @@ describe("Ad API scraper", () => {
             expect(adInfo!.attributes.type).toBe("Some type");
         });
 
-        it("should scrape visits", async () => {
+        it.each`
+            test                    | value        | expected
+            ${"no amount"}          | ${undefined} | ${undefined}
+            ${"non-numeric amount"} | ${"abc"}     | ${undefined}
+            ${"with amount"}        | ${12345}     | ${12345}
+        `("should scrape visits ($test)", async ({value, expected}) => {
             mockResponse(createAdXML({
                 id: "123",
                 title: "My ad title",
                 description: "My ad description",
                 date: new Date(),
-                visits: 12345
+                visits: value
             }));
 
             const adInfo = await scraper(FAKE_VALID_AD_URL);
             validateRequest();
             expect(adInfo).not.toBeNull();
-            expect(adInfo!.attributes.visits).toBe(12345);
+            expect(adInfo!.attributes.visits).toBe(expected);
         });
     });
 });

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -226,18 +226,21 @@ describe("Ad HTML scraper", () => {
 
         describe("attribute scraping", () => {
             it.each`
-                test                | value                            | expectedValue
-                ${"undefined"}      | ${undefined}                     | ${undefined}
-                ${"true boolean"}   | ${"true"}                        | ${true}
-                ${"false boolean"}  | ${"false"}                       | ${false}
-                ${"integer"}        | ${"123"}                         | ${123}
-                ${"float"}          | ${"1.21"}                        | ${1.21}
-                ${"date"}           | ${"2020-09-06T20:52:47.474Z"}    | ${new Date("2020-09-06T20:52:47.474Z")}
-                ${"preciseDate"}    | ${"2021-05-06T00:00:54.978123Z"} | ${new Date("2021-05-06T00:00:54.978123Z")}
-                ${"string"}         | ${"hello"}                       | ${"hello"}
-                ${"datelikeString"} | ${"blah-2021-05-05"}             | ${"blah-2021-05-05"}
-                ${"empty string"}   | ${""}                            | ${""}
-            `("should scrape attribute ($test)", async ({ value, expectedValue }) => {
+                test                        | value                            | extraProperties                                       | expectedValue
+                ${"undefined"}              | ${undefined}                     | ${{}}                                                 | ${undefined}
+                ${"true explicit boolean"}  | ${"1"}                           | ${{ booleanAttribute: true }}                         | ${true}
+                ${"false explicit boolean"} | ${"0"}                           | ${{ booleanAttribute: true }}                         | ${false}
+                ${"true implicit boolean"}  | ${"1"}                           | ${{ localeSpecificValues: { en: { value: "Yes" } } }} | ${true}
+                ${"false implicit boolean"} | ${"0"}                           | ${{ localeSpecificValues: { en: { value: "No" } } }}  | ${false}
+                ${"non-boolean integer"}    | ${"1"}                           | ${{}}                                                 | ${1}
+                ${"integer"}                | ${"123"}                         | ${{}}                                                 | ${123}
+                ${"float"}                  | ${"1.21"}                        | ${{}}                                                 | ${1.21}
+                ${"date"}                   | ${"2020-09-06T20:52:47.474Z"}    | ${{}}                                                 | ${new Date("2020-09-06T20:52:47.474Z")}
+                ${"preciseDate"}            | ${"2021-05-06T00:00:54.978123Z"} | ${{}}                                                 | ${new Date("2021-05-06T00:00:54.978123Z")}
+                ${"string"}                 | ${"hello"}                       | ${{}}                                                 | ${"hello"}
+                ${"datelikeString"}         | ${"blah-2021-05-05"}             | ${{}}                                                 | ${"blah-2021-05-05"}
+                ${"empty string"}           | ${""}                            | ${{}}                                                 | ${""}
+            `("should scrape attribute ($test)", async ({ value, extraProperties, expectedValue }) => {
                 mockResponse(createAdHTML({
                     config: {
                         adInfo: { title: "My ad title" },
@@ -254,7 +257,7 @@ describe("Ad HTML scraper", () => {
                                 { machineKey: 123, machineValue: "invalid" },
 
                                 // Valid
-                                { machineKey: "myAttr", machineValue: value }
+                                { machineKey: "myAttr", machineValue: value, ...extraProperties }
                             ]
                         }
                     }

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -388,7 +388,11 @@ export const categories = {
         FINANCIAL_AND_LEGAL: { id: 131 },
         FITNESS_AND_PERSONAL_TRAINER: { id: 83 },
         FOOD_AND_CATERING: { id: 15214001 },
-        HEALTH_AND_BEAUTY: { id: 166 },
+        HEALTH_AND_BEAUTY: {
+            id: 166,
+            HEALTH_AND_BEAUTY_SERVICES: { id: 1661 },
+            MASSAGE_SERVICES: { id: 1662 }
+        },
         MOVING_AND_STORAGE: { id: 144 },
         MUSIC_LESSONS: { id: 86 },
         PHOTOGRAPHY_AND_VIDEO: { id: 168 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Fixed handling of boolean-like enums in HTML scraper
* Started checking for explicitly-marked booleans so handling can be different in the future if needed
* Properly handle missing visit count in API scraper