### PR TITLE
Update HTML searcher for latest markup, and misc. fixes

### DIFF
--- a/lib/ad.ts
+++ b/lib/ad.ts
@@ -26,7 +26,7 @@ export class Ad extends AdInfo {
      * (e.g., storing ad URLs entered by a user for delayed scraping).
      *
      * `Ad.isScraped()` returns `false` for `Ad` objects constructed in this
-     * way unless `scraped` is passed as `true`or they are subsequently scraped
+     * way unless `scraped` is passed as `true` or they are subsequently scraped
      * by calling `Ad.scrape()`, which causes the scraper to replace the ad's
      * information with what is found at its URL.
      *

--- a/lib/backends/test/api-scraper.spec.ts
+++ b/lib/backends/test/api-scraper.spec.ts
@@ -133,8 +133,8 @@ describe("Ad API scraper", () => {
     it.each`
         test                     | xml
         ${"Bad markup"}          | ${"Bad markup"}
-        ${"Missing id"}          | ${createAdXML({})}
-        ${"Missing title"}       | ${createAdXML({ id: "123" })}
+        ${"Missing ID"}          | ${createAdXML({ title: "My ad title", date: new Date() })}
+        ${"Missing title"}       | ${createAdXML({ id: "123", date: new Date() })}
         ${"Missing date"}        | ${createAdXML({ id: "123", title: "My ad title" })}
     `("should fail to scrape invalid XML ($test)", async ({ xml }) => {
         mockResponse(xml);

--- a/lib/backends/test/api-searcher.spec.ts
+++ b/lib/backends/test/api-searcher.spec.ts
@@ -16,13 +16,13 @@ describe("Search result API scraper", () => {
     });
 
     type MockAdInfo = {
-        url?: string;
-        id?: string;
-        title?: string;
-        date?: Date;
+        url: string;
+        id: string;
+        title: string;
+        date: Date;
     };
 
-    const createAdXML = (info: MockAdInfo) => {
+    const createAdXML = (info: Partial<MockAdInfo>) => {
         return `
             <ad:ad ${info.id ? `id="${info.id}"` : ""}>
                 ${info.url ? `<ad:link rel="self-public-website" href="${info.url}"></ad:link>` : ""}

--- a/lib/backends/test/html-scraper.spec.ts
+++ b/lib/backends/test/html-scraper.spec.ts
@@ -67,8 +67,8 @@ describe("Ad HTML scraper", () => {
         ${"Missing config property"} | ${createAdHTML({ abc: 123 })}
         ${"Missing adInfo property"} | ${createAdHTML({ config: {} })}
         ${"Missing VIP property"}    | ${createAdHTML({ config: { adInfo: {} } })}
-        ${"Missing ID"}              | ${createAdHTML({ config: { adInfo: {}, VIP: {} } })}
-        ${"Missing title"}           | ${createAdHTML({ config: { adInfo: {}, VIP: { adId: 1234 } } })}
+        ${"Missing ID"}              | ${createAdHTML({ config: { adInfo: { title: "Test" }, VIP: { sortingDate: 0 } } })}
+        ${"Missing title"}           | ${createAdHTML({ config: { adInfo: {}, VIP: { adId: 1234, sortingDate: 0 } } })}
         ${"Missing date"}            | ${createAdHTML({ config: { adInfo: { title: "Test" }, VIP: { adId: 1234 } } })}
     `("should fail to scrape invalid HTML ($test)", async ({ html }) => {
         mockResponse(html);

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -3,7 +3,7 @@
 
 import cheerio from "cheerio";
 
-const IMG_REGEX = /\/\$_\d+\.(?:JPG|PNG)$/;
+const IMG_REGEX = /\?rule=kijijica-\d+-/;
 
 /**
  * Kijiji scraping method
@@ -42,10 +42,10 @@ export function isNumber(value: string): boolean {
 };
 
 export function getLargeImageURL(url: string): string {
-    // Kijiji/eBay image URLs typically end with "$_dd.JPG", where "dd" is a
-    // number between 0 and 140 indicating the desired image size and
-    // quality. "57" is up to 1024x1024, the largest I've found.
-    return url.replace(IMG_REGEX, "/$_57.JPG");
+    // Kijiji image URLs typically end with "?rule=kijijica-<num>-<format>",
+    // where "<num>" is a number indicating the width. 960px is the largest
+    // I've found to work.
+    return url.replace(IMG_REGEX, "?rule=kijijica-960-");
 }
 
 export function cleanAdDescription(text: string): string {

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -279,8 +279,9 @@ export function search(params: SearchParameters, options: SearchOptions & Scrape
                 } else {
                     await Promise.all(results.map(ad => {
                         if (!ad.isScraped()) {
-                            ad.scrape();
+                            return ad.scrape();
                         }
+                        return Promise.resolve();
                     }));
                 }
             }

--- a/lib/test/helpers.spec.ts
+++ b/lib/test/helpers.spec.ts
@@ -56,10 +56,10 @@ describe("Helpers", () => {
     });
 
     it.each`
-        test             | url                                     | expectedURL
-        ${"regular URL"} | ${"http://example.com"}                 | ${"http://example.com"}
-        ${"upsize JPG"}  | ${"http://example.com/images/$_12.JPG"} | ${"http://example.com/images/$_57.JPG"}
-        ${"upsize PNG"}  | ${"http://example.com/images/$_34.PNG"} | ${"http://example.com/images/$_57.JPG"}
+        test             | url                                                  | expectedURL
+        ${"regular URL"} | ${"http://example.com"}                              | ${"http://example.com"}
+        ${"upsize JPG"}  | ${"http://example.com/image?rule=kijijica-100-jpg"}  | ${"http://example.com/image?rule=kijijica-960-jpg"}
+        ${"upsize WEBP"} | ${"http://example.com/image?rule=kijijica-640-webp"} | ${"http://example.com/image?rule=kijijica-960-webp"}
     `("getLargeImageURL should upsize image URLs ($test)", ({ url, expectedURL }) => {
         expect(getLargeImageURL(url)).toBe(expectedURL);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kijiji-scraper",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "A scraper for Kijiji ads",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "test": "jest --config jest.config.js",
     "test-integration": "jest ./tests/integrationTests.spec.js",
-    "prepublishOnly": "npm run test"
+    "prepack": "npm run test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Kijiji has changed their CSS class names. They're now all obfuscated (and likely to change frequently as a result). While poking around, I found a JavaScript object in the results page and switched to using that instead (similar to how the HTML scraper works). This should be more reliable.

They've also changed the image URL format, so I updated the large image URL generation logic as well.

Lastly, fixed an issue where scraping with no delay would return before scraping was complete.